### PR TITLE
Fix martin_moron typo + trim whitespace

### DIFF
--- a/_data/people.yml
+++ b/_data/people.yml
@@ -10,7 +10,7 @@ micaela_wolman:
   name: Micaela Wolman
   github: https://github.com/mwolman
 
-guillermo_zorron: 
+guillermo_zorron:
   name: Guillermo Zorron
 
 felipe_facio:

--- a/_meetups/2023-06-08-rootstrap.md
+++ b/_meetups/2023-06-08-rootstrap.md
@@ -10,5 +10,5 @@ talks:
 
  - title: ActiveRecord::RecordNotFound
    speakers:
-     - martín_moron
+     - martin_moron
 ---


### PR DESCRIPTION
![screenshot-ruby uy-2023 07 21-01_44_06](https://github.com/rubyuy/ruby.uy/assets/804303/4fee49d7-37f9-4d53-aa4b-d157a0573e43)
