### PR TITLE
Redesign meetup detail page with card layout and carousel

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,7 @@
-on: [push]
+on:
+  push:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
 
 jobs:
   deploy:
@@ -7,12 +10,15 @@ jobs:
     permissions:
       contents: read
       deployments: write
+      pull-requests: write
 
     name: Deploy to Cloudflare Pages
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -25,11 +31,27 @@ jobs:
           JEKYLL_ENV: production
 
       - name: Publish
+        id: cloudflare
         uses: cloudflare/pages-action@v1.5.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           projectName: ruby-uy
           directory: _site
-          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
           wranglerVersion: '3'
+          branch: ${{ github.event.pull_request.head.ref || github.ref_name }}
+
+      - name: Comment preview URL on PR
+        if: github.event_name == 'pull_request_target'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `🔍 Preview: ${process.env.DEPLOY_URL}`
+            })
+        env:
+          DEPLOY_URL: ${{ steps.cloudflare.outputs.url }}

--- a/Gemfile
+++ b/Gemfile
@@ -32,3 +32,4 @@ gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
 gem "http_parser.rb", "~> 0.6.0", :platforms => [:jruby]
 
 gem "webrick", "~> 1.8"
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,9 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
-    ffi (1.16.3)
+    ffi (1.17.4-arm64-darwin)
+    ffi (1.17.4-x86_64-darwin)
+    ffi (1.17.4-x86_64-linux-gnu)
     forwardable-extended (2.6.0)
     google-protobuf (4.26.1-arm64-darwin)
       rake (>= 13)
@@ -83,6 +85,7 @@ GEM
 PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-21
   x86_64-linux
 

--- a/_includes/meetups.html
+++ b/_includes/meetups.html
@@ -4,6 +4,7 @@
     <p>Conocé el contenido de las ediciones pasadas.</p>
   </header>
 
+  {% assign months_es = "ENE,FEB,MAR,ABR,MAY,JUN,JUL,AGO,SEP,OCT,NOV,DIC" | split: ',' %}
   {% assign meetups_sorted = site.meetups | sort: "date" | reverse %}
 
   {% assign meetups_by_year = meetups_sorted
@@ -12,14 +13,14 @@
         | reverse %}
 
   {% for year in meetups_by_year | reverse %}
-    <h2 class="meetup-event__date_year">{{ year.name }}</h2>
+    <h2 class="meetup-event__date_year" id="meetups-{{ year.name }}">{{ year.name }}</h2>
 
     <ul>
       {% for meetup in year.items %}
         <li class="meetup-event">
           <a href="{{ meetup.url }}" class="meetup-event__link">
             <span class="meetup-event__date">
-              {{ meetup.date | date_to_string }}
+              {% assign m_idx = meetup.date | date: '%m' | minus: 1 %}{{ meetup.date | date: "%d" }} {{ months_es[m_idx] }}
             </span>
             <span class="meetup-event__company">
               {{ meetup.title }}

--- a/_layouts/meetup.html
+++ b/_layouts/meetup.html
@@ -3,75 +3,273 @@
   {% include head.html %}
 
   <body>
+    {% assign host = site.data.companies[page.host] %}
+    {% assign host_name = host.name | default: page.host %}
+    {% assign host_domain = host.url | remove: 'https://' | remove: 'http://' | remove: 'www.' | split: '/' | first %}
+    {% assign year = page.date | date: '%Y' %}
+    {% assign months_es = "ENE,FEB,MAR,ABR,MAY,JUN,JUL,AGO,SEP,OCT,NOV,DIC" | split: ',' %}
+    {% assign month_idx = page.date | date: '%m' | minus: 1 %}
+    {% assign month_name = months_es[month_idx] %}
+
     {% include nav.html %}
 
     <main>
       <article id="view-meetup">
-        <section>
-          <h2>Host</h2>
-          <a href="{{ site.data.companies[page.host].url }}">{{ site.data.companies[page.host].name }}</a>
-        </section>
-
-        <section>
-          <h2>Speakers</h2>
-          <ul>
-            {% for talk in page.talks %}
-            {% for speaker in talk.speakers %}
-            <li>
-              {% if site.data.people[speaker].github %}
-              <a href="https://github.com/{{ site.data.people[speaker].github }}">
-                <img src="https://github.com/{{ site.data.people[speaker].github }}.png?size=30" alt="{{ site.data.people[speaker].name }}" style="border-radius: 50%; width: 30px"/>{{ site.data.people[speaker].name }}
-              </a>
-              {% else %}
-              {{ site.data.people[speaker].name }}
-              {% endif %}
-            </li>
-            {% endfor %}
-            {% endfor %}
-          </ul>
-        </section>
-
-        <section>
-          <h2>Charlas</h2>
-
-          {% for talk in page.talks %}
-          <div class="talk">
-            {% assign speakers = "" | split: ',' %}
-
-            {% for speaker in talk.speakers %}
-            {% assign speakers = speakers | push: site.data.people[speaker].name %}
-            {% endfor %}
-
-            <h3 id="{{ talk.title | slugify }}">
-              <a href="#{{ talk.title | slugify }}">
-                <span class="talk-title">{{ talk.title }}</span>
-              </a>
-              <p>{{ speakers | join: ", " }}</p>
-            </h3>
-
-            <p>{{ talk.description }}<p>
-
-            {% if talk.recording %}
-            <div class="keep-aspect-ratio">
-              <iframe src="{{ talk.recording }}" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen>
-              </iframe>
-            </div>
-            {% endif %}
-
-            {% if talk.slides %}
-            <div class="keep-aspect-ratio">
-              <iframe src="{{ talk.slides }}" frameborder="0" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true">
-              </iframe>
-            </div>
-            {% endif %}
-
+        <nav class="view-meetup__breadcrumb" aria-label="breadcrumb">
+          <div class="breadcrumb__inner">
+            <ol class="breadcrumb__trail">
+              <li><a href="/">RUBY.UY</a></li>
+              <li><span aria-hidden="true">/</span></li>
+              <li><a href="/#meetups">MEETUPS</a></li>
+              <li><span aria-hidden="true">/</span></li>
+              <li><a href="/#meetups-{{ year }}">{{ year }}</a></li>
+              <li><span aria-hidden="true">/</span></li>
+              <li class="breadcrumb__current">{{ host_name | upcase }}</li>
+            </ol>
           </div>
-          {% endfor %}
+        </nav>
+
+        <section class="view-meetup__hero">
+          <div class="hero__inner">
+            <div class="hero__left">
+              <div class="hero__heading">
+                <div class="date-badge" aria-label="{{ page.date | date: '%Y-%m-%d' }}">
+                  <span class="date-badge__day">{{ page.date | date: '%d' }}</span>
+                  <span class="date-badge__month">{{ month_name }}</span>
+                  <span class="date-badge__year">{{ year }}</span>
+                </div>
+                <div class="hero__title-block">
+                  <span class="hero__pill">MEETUP</span>
+                  <h1 class="hero__title">
+                    <span class="hero__title-line">RUBY MEETUP</span>
+                    <span class="hero__title-line">@ {{ host_name | upcase }}</span>
+                  </h1>
+                </div>
+              </div>
+
+              {% if page.description %}
+              <p class="hero__description">{{ page.description }}</p>
+              {% endif %}
+            </div>
+
+            <div class="hero__right" aria-hidden="true">
+              <div class="hero__illustration">
+                <svg viewBox="0 0 320 220" xmlns="http://www.w3.org/2000/svg">
+                  <g fill="#3967D1" opacity="0.16">
+                    {% for row in (0..7) %}
+                      {% for col in (0..8) %}
+                        <circle cx="{{ col | times: 20 | plus: 145 }}" cy="{{ row | times: 20 | plus: 15 }}" r="2"/>
+                      {% endfor %}
+                    {% endfor %}
+                  </g>
+                  <g transform="translate(160, 110)">
+                    <polygon points="-140,-20 -90,-90 90,-90 140,-20 0,90"
+                             fill="#E63946"
+                             stroke="#9B1F2D"
+                             stroke-width="1.6"
+                             stroke-linejoin="round"/>
+                    <polygon points="-80,-20 -45,-90 45,-90 80,-20"
+                             fill="#FF6B7A"
+                             fill-opacity="0.55"/>
+                    <polygon points="-140,-20 140,-20 0,90"
+                             fill="#9B1F2D"
+                             fill-opacity="0.2"/>
+                    <g stroke="#9B1F2D" stroke-width="0.9" fill="none" opacity="0.42">
+                      <line x1="-80" y1="-20" x2="-45" y2="-90"/>
+                      <line x1="80" y1="-20" x2="45" y2="-90"/>
+                      <line x1="-80" y1="-20" x2="0" y2="90"/>
+                      <line x1="80" y1="-20" x2="0" y2="90"/>
+                      <line x1="-140" y1="-20" x2="140" y2="-20"/>
+                    </g>
+                  </g>
+                </svg>
+              </div>
+            </div>
+          </div>
         </section>
-        <section> {{ content }} </section>
+
+        <section class="view-meetup__grid-section">
+          <div class="grid-section__inner">
+            <div class="view-meetup__grid">
+              <div class="view-meetup__col view-meetup__col--left">
+                <section class="card host-card">
+                  <span class="card__label card__label--host">HOST</span>
+                  <div class="host-card__body">
+                    {% if host.image %}
+                    <div class="host-card__logo-tile">
+                      <img class="host-card__logo" src="{{ host.image }}" alt="{{ host_name }}">
+                    </div>
+                    {% endif %}
+                    <div class="host-card__info">
+                      <h2 class="host-card__name">{{ host_name | upcase }}</h2>
+                      {% if host.description %}
+                      <p class="host-card__description">{{ host.description }}</p>
+                      {% endif %}
+                      {% if host.url %}
+                      <a class="host-card__link" href="{{ host.url }}" target="_blank" rel="noopener">
+                        {{ host_domain }} <span class="host-card__link-icon" aria-hidden="true">↗</span>
+                      </a>
+                      {% endif %}
+                    </div>
+                  </div>
+                </section>
+
+                {% assign seen_speakers = "" | split: "," %}
+                {% assign any_speakers = false %}
+                {% for talk in page.talks %}
+                  {% for speaker_key in talk.speakers %}
+                    {% unless seen_speakers contains speaker_key %}
+                      {% assign seen_speakers = seen_speakers | push: speaker_key %}
+                      {% assign any_speakers = true %}
+                    {% endunless %}
+                  {% endfor %}
+                {% endfor %}
+
+                {% if any_speakers %}
+                <section class="card speakers-card">
+                  <span class="card__label card__label--speakers">SPEAKERS</span>
+                  <ul class="speakers-list">
+                    {% for speaker_key in seen_speakers %}
+                      {% assign speaker = site.data.people[speaker_key] %}
+                      <li class="speaker">
+                        {% if speaker.photo %}
+                          <img class="speaker__avatar" src="{{ speaker.photo }}" alt="{{ speaker.name }}">
+                        {% elsif speaker.github %}
+                          <img class="speaker__avatar" src="https://github.com/{{ speaker.github }}.png?size=200" alt="{{ speaker.name }}">
+                        {% else %}
+                          {% assign speaker_name_parts = speaker.name | split: " " %}
+                          {% assign speaker_initial_first = speaker_name_parts[0] | slice: 0 | upcase %}
+                          {% if speaker_name_parts.size > 1 %}
+                            {% assign speaker_last_part = speaker_name_parts | last %}
+                            {% assign speaker_initial_last = speaker_last_part | slice: 0 | upcase %}
+                            {% assign speaker_initials = speaker_initial_first | append: speaker_initial_last %}
+                          {% else %}
+                            {% assign speaker_initials = speaker_initial_first %}
+                          {% endif %}
+                          <span class="speaker__avatar speaker__avatar--placeholder" aria-hidden="true">{{ speaker_initials }}</span>
+                        {% endif %}
+                        <div class="speaker__info">
+                          <h3 class="speaker__name">{{ speaker.name | upcase }}</h3>
+                          {% if speaker.role %}
+                          <p class="speaker__role">{{ speaker.role }}</p>
+                          {% endif %}
+                          <ul class="speaker__socials">
+                            {% if speaker.github %}
+                            <li>
+                              <a href="https://github.com/{{ speaker.github }}" target="_blank" rel="noopener">
+                                GitHub <span class="speaker__socials-arrow" aria-hidden="true">↗</span>
+                              </a>
+                            </li>
+                            {% endif %}
+                            {% if speaker.twitter %}
+                            <li>
+                              <a href="https://twitter.com/{{ speaker.twitter }}" target="_blank" rel="noopener">
+                                Twitter <span class="speaker__socials-arrow" aria-hidden="true">↗</span>
+                              </a>
+                            </li>
+                            {% endif %}
+                          </ul>
+                        </div>
+                      </li>
+                    {% endfor %}
+                  </ul>
+                </section>
+                {% endif %}
+              </div>
+
+              <div class="view-meetup__col view-meetup__col--right">
+                <section class="card charla-destacada" id="charla-destacada">
+                  {% if page.talks.size > 0 %}
+                  <header class="charla-destacada__header">
+                    <span class="charla-destacada__counter" data-counter aria-live="polite">
+                      01 / {% if page.talks.size < 10 %}0{% endif %}{{ page.talks.size }}
+                    </span>
+                  </header>
+                  {% endif %}
+
+                  <div class="carousel" data-carousel>
+                    <ol class="carousel__track" data-track>
+                      {% for talk in page.talks %}
+                      <li class="slide" data-slide>
+                        <h3 class="slide__title" id="{{ talk.title | slugify }}">
+                          <a href="#{{ talk.title | slugify }}">
+                            {{ talk.title | upcase }}
+                          </a>
+                        </h3>
+
+                        <p class="slide__speakers">
+                          {% for speaker_key in talk.speakers %}
+                            {% assign speaker = site.data.people[speaker_key] %}
+                            {% if speaker.photo %}
+                              <img class="slide__speaker-avatar" src="{{ speaker.photo }}" alt="{{ speaker.name }}">
+                            {% elsif speaker.github %}
+                              <img class="slide__speaker-avatar" src="https://github.com/{{ speaker.github }}.png?size=60" alt="{{ speaker.name }}">
+                            {% else %}
+                              <span class="slide__speaker-avatar slide__speaker-avatar--placeholder" aria-hidden="true"></span>
+                            {% endif %}
+                            <span>{{ speaker.name }}</span>{% unless forloop.last %}<span class="slide__speaker-sep">, </span>{% endunless %}
+                          {% endfor %}
+                        </p>
+
+                        {% if talk.recording %}
+                        <div class="keep-aspect-ratio">
+                          <iframe src="{{ talk.recording }}" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen loading="lazy"></iframe>
+                        </div>
+                        {% endif %}
+
+                        {% if talk.slides %}
+                        <div class="keep-aspect-ratio">
+                          <iframe src="{{ talk.slides }}" frameborder="0" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true" loading="lazy"></iframe>
+                        </div>
+                        {% endif %}
+
+                        {% if talk.topics or talk.duration %}
+                        <footer class="slide__footer">
+                          {% if talk.topics %}
+                          <div class="slide__meta slide__meta--tema">
+                            <span class="slide__meta-label">TEMA</span>
+                            <span class="slide__meta-value">{{ talk.topics | join: ', ' }}</span>
+                          </div>
+                          {% endif %}
+                          {% if talk.duration %}
+                          <div class="slide__meta slide__meta--duracion">
+                            <span class="slide__meta-label">DURACIÓN</span>
+                            <span class="slide__meta-value">{{ talk.duration }}</span>
+                          </div>
+                          {% endif %}
+                        </footer>
+                        {% endif %}
+                      </li>
+                      {% endfor %}
+                    </ol>
+
+                    {% if page.talks.size > 1 %}
+                    <button class="carousel__btn carousel__btn--prev" type="button" data-prev aria-label="Charla anterior">&lsaquo;</button>
+                    <button class="carousel__btn carousel__btn--next" type="button" data-next aria-label="Siguiente charla">&rsaquo;</button>
+                    {% endif %}
+                  </div>
+                </section>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {% if content and content != "" %}
+        <section class="view-meetup__content">{{ content }}</section>
+        {% endif %}
+
+        <nav class="view-meetup__footer-bar">
+          <div class="footer-bar__inner">
+            <a href="/#meetups">&larr; VER MÁS EDICIONES PASADAS</a>
+          </div>
+        </nav>
       </article>
     </main>
-  </body>
 
-  {% include footer.html %}
+    {% if page.talks.size > 0 %}
+    <script src="/assets/js/meetup_carousel.js" defer></script>
+    {% endif %}
+
+    {% include footer.html %}
+  </body>
 </html>

--- a/_sass/meetups.scss
+++ b/_sass/meetups.scss
@@ -1,5 +1,9 @@
 #meetups {
   background-color: #F6EEEC;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  width: 100%;
 
   header {
     background-color: #3967D1;
@@ -36,10 +40,12 @@
 
   .meetup-event__date_year {
     align-items: center;
+    border-bottom: 2px solid #2851AE;
     display: flex;
-    padding: 1.5rem 8rem;
     font-weight: bold;
     justify-content: space-between;
+    margin: 2.75rem 0 0.875rem;
+    padding: 1.25rem 8rem 0.625rem;
   }
 
   ul {

--- a/_sass/view_meetup.scss
+++ b/_sass/view_meetup.scss
@@ -1,65 +1,816 @@
-#view-meetup {
-  margin: 0 auto;
-  width: 85%;
+$vm-blue: #3967D1;
+$vm-yellow: #FFC24D;
+$vm-cream: #F3EEED;
+$vm-ink: #2E2E2E;
+$vm-green: #397E78;
+$vm-red: #E63946;
+$vm-white: #ffffff;
 
-  @media (min-width: 1024px) {
-    width: 65%;
+$vm-container: 1600px;
+$vm-pad-x: 4rem;
+
+#view-meetup,
+#view-meetup * {
+  box-sizing: border-box;
+}
+
+#view-meetup {
+  background: $vm-cream;
+  color: $vm-ink;
+  font-family: 'Syncopate', sans-serif;
+  width: 100%;
+}
+
+// ============================================================
+// Breadcrumb bar
+// ============================================================
+
+.view-meetup__breadcrumb {
+  background: $vm-blue;
+  color: $vm-white;
+  width: 100%;
+
+  .breadcrumb__inner {
+    align-items: center;
+    display: flex;
+    gap: 1rem;
+    height: 88px;
+    justify-content: space-between;
+    margin: 0 auto;
+    max-width: $vm-container;
+    padding: 0 $vm-pad-x;
+    width: 100%;
   }
 
-  section {
+  .breadcrumb__trail {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    font-size: 0.8125rem;
+    font-weight: 700;
+    gap: 0.875rem;
+    letter-spacing: 0.08em;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .breadcrumb__trail a {
+    color: $vm-white;
+    text-decoration: none;
+
+    &:hover {
+      color: $vm-yellow;
+    }
+  }
+
+  .breadcrumb__trail li[aria-hidden] {
+    color: rgba($vm-white, 0.55);
+  }
+
+  .breadcrumb__current {
+    color: $vm-yellow;
+  }
+
+  @media (max-width: 900px) {
+    .breadcrumb__inner {
+      height: auto;
+      padding: 1rem 1.5rem;
+    }
+
+    .breadcrumb__trail {
+      font-size: 0.75rem;
+    }
+  }
+}
+
+// ============================================================
+// Hero
+// ============================================================
+
+.view-meetup__hero {
+  background: $vm-cream;
+  width: 100%;
+
+  .hero__inner {
+    border-bottom: 3px solid $vm-ink;
+    display: grid;
+    gap: 2.5rem;
+    grid-template-columns: minmax(0, 58fr) minmax(0, 42fr);
+    margin: 0 auto;
+    max-width: $vm-container;
+    padding: 2.25rem $vm-pad-x 2rem;
     width: 100%;
-    margin-top: 1.25rem;
+  }
+
+  .hero__left {
+    align-self: center;
     display: flex;
     flex-direction: column;
-    margin-bottom: 3rem;
+    max-width: 660px;
+    min-width: 0;
+  }
+
+  .hero__heading {
+    align-items: flex-start;
+    display: flex;
+    gap: 1.5rem;
+  }
+
+  .date-badge {
+    align-items: center;
+    background: $vm-cream;
+    border: 2.5px solid $vm-blue;
+    border-radius: 12px;
+    box-shadow: 4px 4px 0 $vm-ink;
+    color: $vm-blue;
+    display: flex;
+    flex: 0 0 auto;
+    flex-direction: column;
+    font-weight: 700;
+    height: 152px;
+    justify-content: center;
+    min-width: 104px;
+    padding: 0.75rem;
+    text-align: center;
+    width: 104px;
+  }
+
+  .date-badge__day {
+    font-size: 2.5rem;
+    line-height: 1;
+  }
+
+  .date-badge__month {
+    font-size: 0.9375rem;
+    letter-spacing: 0.12em;
+    margin-top: 0.6rem;
+  }
+
+  .date-badge__year {
+    font-size: 0.75rem;
+    letter-spacing: 0.1em;
+    margin-top: 0.4rem;
+  }
+
+  .hero__title-block {
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    gap: 0.5rem;
+    min-width: 0;
+    padding-top: 0.25rem;
+  }
+
+  .hero__pill {
+    align-items: center;
+    background: transparent;
+    border: 1.5px solid rgba($vm-blue, 0.75);
+    border-radius: 10px;
+    color: $vm-blue;
+    display: inline-flex;
+    font-size: 0.75rem;
+    font-weight: 700;
+    height: 32px;
+    justify-content: center;
+    letter-spacing: 0.18em;
+    min-width: 92px;
+    padding: 0 0.75rem;
+    width: fit-content;
+  }
+
+  .hero__title {
+    color: $vm-blue;
+    font-size: clamp(2rem, 4vw, 3.375rem);
+    font-weight: 700;
+    letter-spacing: -0.018em;
+    line-height: 1;
+    margin: 0;
+  }
+
+  .hero__title-line {
+    display: block;
+  }
+
+  .hero__description {
+    color: rgba($vm-ink, 0.82);
+    font-family: 'DM Sans', system-ui, sans-serif;
+    font-size: 1.125rem;
+    line-height: 1.6;
+    margin: 1.5rem 0 0;
+    max-width: 84%;
+  }
+
+  .hero__right {
+    align-items: center;
+    display: flex;
+    justify-content: center;
+    min-width: 0;
+    position: relative;
+  }
+
+  .hero__illustration {
+    align-items: center;
+    display: flex;
+    height: 196px;
+    justify-content: center;
+    max-width: 280px;
+    width: 100%;
+  }
+
+  .hero__illustration svg {
+    height: 100%;
+    max-height: 100%;
+    max-width: 100%;
+    width: 100%;
+  }
+
+  @media (max-width: 980px) {
+    .hero__inner {
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      padding: 1.75rem 2rem 1.75rem;
+    }
+
+    .hero__left {
+      max-width: none;
+    }
+
+    .hero__right {
+      display: none;
+    }
+  }
+
+  @media (max-width: 640px) {
+    .hero__heading {
+      flex-wrap: wrap;
+      gap: 1.25rem;
+    }
+
+    .date-badge {
+      height: 128px;
+      min-width: 96px;
+      width: 96px;
+    }
+
+    .date-badge__day {
+      font-size: 2.125rem;
+    }
+  }
+}
+
+// ============================================================
+// Grid section
+// ============================================================
+
+.view-meetup__grid-section {
+  background: $vm-cream;
+  width: 100%;
+
+  .grid-section__inner {
+    margin: 0 auto;
+    max-width: $vm-container;
+    padding: 2rem $vm-pad-x 3rem;
+    width: 100%;
+  }
+}
+
+.view-meetup__grid {
+  display: grid;
+  gap: 1.75rem;
+  grid-template-columns: minmax(0, 45fr) minmax(0, 55fr);
+
+  @media (max-width: 980px) {
+    gap: 1.5rem;
+    grid-template-columns: 1fr;
+  }
+}
+
+.view-meetup__col {
+  display: flex;
+  flex-direction: column;
+  gap: 1.375rem;
+  min-width: 0;
+}
+
+// ============================================================
+// Shared card
+// ============================================================
+
+.card {
+  background: $vm-white;
+  border: 3px solid $vm-blue;
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  padding: 1.75rem;
+  position: relative;
+
+  .card__label {
+    align-items: center;
+    background: $vm-green;
+    border-radius: 10px;
+    color: $vm-white;
+    display: inline-flex;
+    font-size: 0.6875rem;
+    font-weight: 700;
+    gap: 0.45rem;
+    height: 32px;
+    left: 1.5rem;
+    letter-spacing: 0.12em;
+    padding: 0 1.125rem;
+    position: absolute;
+    text-transform: uppercase;
+    top: -16px;
+    z-index: 1;
+
+    &--speakers {
+      background: $vm-blue;
+    }
+
+    &--charla {
+      background: $vm-red;
+    }
+  }
+
+  .card__label-icon {
+    align-items: center;
+    display: inline-flex;
+    height: 0.8rem;
+    justify-content: center;
+    line-height: 1;
+    width: 0.8rem;
+  }
+
+  .card__label-icon svg {
+    display: block;
+    height: 100%;
+    width: 100%;
+  }
+}
+
+// ============================================================
+// Host card
+// ============================================================
+
+.host-card {
+  min-height: 220px;
+  padding: 1.75rem;
+
+  .host-card__body {
+    align-items: center;
+    display: flex;
+    gap: 1.5rem;
+    height: 100%;
+  }
+
+  .host-card__logo-tile {
+    align-items: center;
+    background: #F7F4F2;
+    border-radius: 10px;
+    display: flex;
+    flex: 0 0 auto;
+    height: 104px;
+    justify-content: center;
+    padding: 1rem;
+    width: 104px;
+  }
+
+  .host-card__logo {
+    display: block;
+    max-height: 100%;
+    max-width: 100%;
+    object-fit: contain;
+  }
+
+  .host-card__info {
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    min-width: 0;
+  }
+
+  .host-card__name {
+    color: $vm-ink;
+    font-size: 1.8125rem;
+    font-weight: 700;
+    letter-spacing: 0.015em;
+    line-height: 1.05;
+    margin: 0 0 0.625rem;
+    text-decoration: none;
+  }
+
+  .host-card__description {
+    color: rgba($vm-ink, 0.72);
+    font-family: 'DM Sans', system-ui, sans-serif;
+    font-size: 1rem;
+    line-height: 1.55;
+    margin: 0 0 0.875rem;
+    max-width: 38ch;
+  }
+
+  .host-card__link {
+    align-items: baseline;
+    color: $vm-blue;
+    display: inline-flex;
+    font-family: 'DM Sans', system-ui, sans-serif;
+    font-size: 0.875rem;
+    font-weight: 600;
+    gap: 0.35rem;
+    letter-spacing: 0.02em;
+    margin-top: 0;
+    text-decoration: none;
+    word-break: break-all;
+
+    &:hover,
+    &:focus-visible {
+      text-decoration: underline;
+    }
+  }
+
+  .host-card__link-icon {
+    font-size: 0.9em;
+    line-height: 1;
+    opacity: 0.85;
+  }
+
+  @media (max-width: 520px) {
+    .host-card__body {
+      flex-direction: column;
+    }
+
+    .host-card__name {
+      font-size: 1.5rem;
+    }
+
+    .host-card__link {
+      margin-top: 1rem;
+    }
+  }
+}
+
+// ============================================================
+// Speakers card
+// ============================================================
+
+.speakers-card {
+  justify-content: center;
+  min-height: 370px;
+  padding: 1.625rem 1.75rem 1.75rem;
+
+  .speakers-list {
+    display: flex;
+    flex-direction: column;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .speaker {
+    align-items: flex-start;
+    display: flex;
+    gap: 1.375rem;
+    min-height: 128px;
+    padding: 1.125rem 0;
+
+    & + .speaker {
+      border-top: 1px solid rgba($vm-ink, 0.1);
+    }
 
     &:first-child {
-      margin-top: 4rem;
+      padding-top: 0.375rem;
     }
   }
 
-  a {
-    font-size: 1.25rem;
+  .speaker__avatar {
+    background: $vm-cream;
+    border-radius: 50%;
+    flex: 0 0 auto;
+    height: 92px;
+    object-fit: cover;
+    width: 92px;
   }
 
-  h2 {
-    margin-bottom: 1rem;
-    font-weight: bold;
-    font-size: 2.5rem;
+  .speaker__avatar--placeholder {
+    align-items: center;
+    color: rgba($vm-ink, 0.55);
+    display: flex;
+    font-family: 'Syncopate', sans-serif;
+    font-size: 1.5rem;
+    font-weight: 600;
+    justify-content: center;
+    letter-spacing: 0.04em;
   }
 
-  h3 {
-    margin-bottom: 1rem;
-    font-size: 1.25rem;
-    overflow-wrap: break-word;
+  .speaker__info {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    padding-top: 0.5rem;
   }
 
-  span {
-    font-weight: bold;
+  .speaker__name {
+    color: $vm-blue;
+    font-size: 1.375rem;
+    font-weight: 700;
+    letter-spacing: 0.015em;
+    line-height: 1.1;
+    margin: 0;
+    text-decoration: none;
   }
 
-  .keep-aspect-ratio {
+  .speaker__role {
+    color: rgba($vm-ink, 0.7);
+    font-family: 'DM Sans', system-ui, sans-serif;
+    font-size: 0.9375rem;
+    line-height: 1.45;
+    margin: 0.35rem 0 0;
+  }
+
+  .speaker__socials {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.375rem 1.25rem;
+    list-style: none;
+    margin: 0.625rem 0 0;
+    padding: 0;
+
+    a {
+      align-items: baseline;
+      color: $vm-blue;
+      display: inline-flex;
+      font-family: 'DM Sans', system-ui, sans-serif;
+      font-size: 0.875rem;
+      font-weight: 600;
+      gap: 0.35rem;
+      letter-spacing: 0.02em;
+      text-decoration: none;
+
+      &:hover,
+      &:focus-visible {
+        text-decoration: underline;
+      }
+    }
+
+    .speaker__socials-arrow {
+      font-size: 0.9em;
+      line-height: 1;
+      opacity: 0.85;
+    }
+  }
+}
+
+// ============================================================
+// Charla destacada card (right column)
+// ============================================================
+
+.charla-destacada {
+  flex: 1 1 auto;
+  min-height: 560px;
+  padding: 1.625rem 1.75rem 1.75rem;
+
+  .charla-destacada__header {
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: 1.125rem;
+  }
+
+  .charla-destacada__counter {
+    color: $vm-blue;
+    font-size: 0.8125rem;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+  }
+
+  .carousel {
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    min-height: 0;
     position: relative;
-    width: 100%;
-    padding-top: 56.25%;
-    margin-bottom: 1.25rem;
+  }
 
-    iframe {
-      position: absolute;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
+  .carousel__track {
+    display: flex;
+    flex: 1 1 auto;
+    list-style: none;
+    margin: 0;
+    min-height: 0;
+    overflow-x: auto;
+    padding: 0;
+    scroll-behavior: smooth;
+    scroll-snap-type: x mandatory;
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+      display: none;
     }
   }
 
-  .talk {
-    margin-bottom: 2rem;
+  .slide {
+    display: flex;
+    flex: 0 0 100%;
+    flex-direction: column;
+    min-height: 0;
+    scroll-snap-align: start;
+    width: 100%;
+  }
 
-    h3 {
-      a {
-        font-size: 1.75rem;
+  .slide__title {
+    font-size: 1.625rem;
+    font-weight: 700;
+    letter-spacing: -0.005em;
+    line-height: 1.2;
+    margin: 0 0 2.125rem;
+    max-width: 58%;
+    overflow-wrap: break-word;
+    text-wrap: balance;
+
+    a {
+      color: $vm-blue;
+      text-decoration: none;
+
+      &:hover,
+      &:focus-visible {
+        text-decoration: underline;
       }
     }
   }
+
+  .slide__speakers {
+    align-items: center;
+    color: rgba($vm-ink, 0.7);
+    display: flex;
+    flex-wrap: wrap;
+    font-family: 'DM Sans', system-ui, sans-serif;
+    font-size: 0.9375rem;
+    gap: 0.5rem;
+    margin: 0 0 1.5rem;
+    min-height: 36px;
+    padding: 0;
+  }
+
+  .slide__speaker-avatar {
+    border-radius: 50%;
+    height: 26px;
+    object-fit: cover;
+    width: 26px;
+  }
+
+  .slide__speaker-avatar--placeholder {
+    background: $vm-cream;
+    display: inline-block;
+  }
+
+  .keep-aspect-ratio {
+    aspect-ratio: 16 / 9;
+    background: #111;
+    border-radius: 8px;
+    margin: 0 0 1.75rem;
+    overflow: hidden;
+    position: relative;
+    width: 100%;
+
+    iframe {
+      border: 0;
+      height: 100%;
+      left: 0;
+      position: absolute;
+      top: 0;
+      width: 100%;
+    }
+  }
+
+  .slide__footer {
+    border-top: 1px solid rgba($vm-ink, 0.1);
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    justify-content: space-between;
+    margin-top: 0;
+    padding-top: 1.25rem;
+  }
+
+  .slide__meta {
+    align-items: center;
+    display: flex;
+    font-size: 0.75rem;
+    font-weight: 700;
+    gap: 0.625rem;
+    letter-spacing: 0.06em;
+  }
+
+  .slide__meta-label {
+    align-items: center;
+    background: $vm-green;
+    border-radius: 7px;
+    color: $vm-white;
+    display: inline-flex;
+    height: 28px;
+    padding: 0 0.75rem;
+  }
+
+  .slide__meta--duracion .slide__meta-label {
+    background: $vm-blue;
+  }
+
+  .slide__meta-value {
+    color: rgba($vm-ink, 0.85);
+  }
+
+  .carousel__btn {
+    align-items: center;
+    background: $vm-white;
+    border: 2px solid $vm-blue;
+    border-radius: 50%;
+    color: $vm-blue;
+    cursor: pointer;
+    display: flex;
+    font-size: 1.25rem;
+    font-weight: 700;
+    height: 40px;
+    justify-content: center;
+    line-height: 1;
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 40px;
+    z-index: 2;
+
+    &:hover:not([disabled]) {
+      background: $vm-blue;
+      color: $vm-white;
+    }
+
+    &[disabled] {
+      cursor: default;
+      opacity: 0.35;
+    }
+  }
+
+  .carousel__btn--prev {
+    left: 8px;
+  }
+
+  .carousel__btn--next {
+    right: 8px;
+  }
+
+  @media (max-width: 640px) {
+    .carousel__btn--prev {
+      left: 4px;
+    }
+
+    .carousel__btn--next {
+      right: 4px;
+    }
+
+    .slide__footer {
+      align-items: flex-start;
+      flex-direction: column;
+    }
+  }
+}
+
+// ============================================================
+// Footer bar
+// ============================================================
+
+.view-meetup__footer-bar {
+  background: $vm-cream;
+  border-top: 3px solid $vm-ink;
+  width: 100%;
+
+  .footer-bar__inner {
+    margin: 0 auto;
+    max-width: $vm-container;
+    padding: 1.625rem $vm-pad-x;
+    text-align: center;
+    width: 100%;
+  }
+
+  a {
+    color: $vm-blue;
+    font-size: 0.875rem;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-decoration: none;
+    text-transform: uppercase;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}
+
+// ============================================================
+// Optional body content after cards
+// ============================================================
+
+.view-meetup__content {
+  background: $vm-cream;
+  margin: 0 auto;
+  max-width: $vm-container;
+  padding: 0 $vm-pad-x 2rem;
+  width: 100%;
 }

--- a/assets/js/meetup_carousel.js
+++ b/assets/js/meetup_carousel.js
@@ -1,0 +1,87 @@
+(function () {
+  'use strict';
+
+  function pad2(n) {
+    return n < 10 ? '0' + n : String(n);
+  }
+
+  function initCarousel(root) {
+    var track = root.querySelector('[data-track]');
+    var slides = root.querySelectorAll('[data-slide]');
+    var prevBtn = root.querySelector('[data-prev]');
+    var nextBtn = root.querySelector('[data-next]');
+    var counter = root.closest('.charla-destacada').querySelector('[data-counter]');
+
+    if (!track || slides.length === 0) {
+      return;
+    }
+
+    var total = slides.length;
+    var current = 0;
+
+    function updateCounter() {
+      if (counter) {
+        counter.textContent = pad2(current + 1) + ' / ' + pad2(total);
+      }
+      if (prevBtn) {
+        prevBtn.disabled = current === 0;
+      }
+      if (nextBtn) {
+        nextBtn.disabled = current === total - 1;
+      }
+    }
+
+    function scrollToIndex(index) {
+      var target = slides[index];
+      if (!target) return;
+      target.scrollIntoView({ inline: 'start', behavior: 'smooth', block: 'nearest' });
+    }
+
+    if (prevBtn) {
+      prevBtn.addEventListener('click', function () {
+        if (current > 0) scrollToIndex(current - 1);
+      });
+    }
+
+    if (nextBtn) {
+      nextBtn.addEventListener('click', function () {
+        if (current < total - 1) scrollToIndex(current + 1);
+      });
+    }
+
+    if ('IntersectionObserver' in window) {
+      var observer = new IntersectionObserver(
+        function (entries) {
+          entries.forEach(function (entry) {
+            if (entry.isIntersecting && entry.intersectionRatio >= 0.6) {
+              var idx = Array.prototype.indexOf.call(slides, entry.target);
+              if (idx !== -1 && idx !== current) {
+                current = idx;
+                updateCounter();
+              }
+            }
+          });
+        },
+        { root: track, threshold: [0.6] }
+      );
+      slides.forEach(function (slide) {
+        observer.observe(slide);
+      });
+    }
+
+    updateCounter();
+  }
+
+  function init() {
+    var carousels = document.querySelectorAll('[data-carousel]');
+    carousels.forEach(function (root) {
+      initCarousel(root);
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();


### PR DESCRIPTION
## Summary

- Replaces the plain meetup detail layout with a breadcrumb nav, hero section, and two-column card grid (host + speakers on the left, talk carousel on the right)
- Adds a vanilla JS carousel using scroll-snap + IntersectionObserver with prev/next buttons and a slide counter
- Updates the meetup list to use Spanish month abbreviations and adds year anchor IDs for breadcrumb deep-links
- Fixes accessible breadcrumb separators (`aria-hidden` on inner `<span>`, not `<li>`) and adds `speaker.photo` fallback in carousel slide avatars

## Test plan

- [ ] Visit a meetup detail page and verify hero, host card, speakers card, and talk carousel render correctly
- [ ] Verify carousel prev/next buttons navigate between talks and the counter updates
- [ ] Verify breadcrumb links navigate to `/#meetups` and `/#meetups-{year}`
- [ ] Check a speaker with only `photo` (no `github`) shows their avatar in both the speakers card and carousel slide
- [ ] Verify the meetup list shows Spanish month abbreviations (e.g. "06 ABR")
- [ ] Test on mobile (≤980px) — layout should stack to single column
