### PR TITLE
Add talks view + search bar

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,6 +3,7 @@
     <h1>
       <a href="mailto:org@ruby.uy" target="_blank">org@ruby.uy</a>
     </h1>
+    <p><a href="/charlas">Buscar charlas</a></p>
     <ul>
       <li>
         <a href="https://twitter.com/rubymontevideo" target="_blank"><img src="/assets/images/twitter.svg" alt="Twitter Icon"></a>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -16,4 +16,5 @@
   <script src="{{ "nav" | js_asset | buster }}"></script>
   <script src="{{ "next_meetup_callout" | js_asset | buster }}"></script>
   <script src="{{ "sponsors" | js_asset | buster }}"></script>
+  <script src="{{ "talks" | js_asset | buster }}"></script>
 </head>

--- a/_includes/meetups.html
+++ b/_includes/meetups.html
@@ -2,6 +2,10 @@
   <header>
     <h1>EDICIONES PASADAS</h1>
     <p>Conocé el contenido de las ediciones pasadas.</p>
+    <a href="/charlas" class="meetup-event__search-link">
+      Buscar entre todas las charlas
+      <img src="/assets/images/arrow.svg" aria-hidden="true">
+    </a>
   </header>
 
   {% assign meetups_sorted = site.meetups | sort: "date" | reverse %}

--- a/_layouts/meetup.html
+++ b/_layouts/meetup.html
@@ -6,7 +6,7 @@
     {% include nav.html %}
 
     <main>
-      <article id="view-meetup">
+      <article id="view-meetup" class="view">
         <section>
           <h2>Host</h2>
           <a href="{{ site.data.companies[page.host].url }}">{{ site.data.companies[page.host].name }}</a>

--- a/_layouts/talks.html
+++ b/_layouts/talks.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="es">
+  {% include head.html %}
+
+  <body>
+    {% include nav.html %}
+
+    <main>
+      <article id="view-talks" class="view">
+        <section>
+          <h2>Charlas</h2>
+
+          <input type="search" id="talks-search" class="talks-search" placeholder="Buscar charla o speaker..." autocomplete="off">
+        </section>
+
+        <section>
+          {% assign meetups_sorted = site.meetups | sort: "date" | reverse %}
+          {% assign meetups_grouped = meetups_sorted | group_by_exp: "m", "m.date | date: '%Y'" %}
+
+          {% for year in meetups_grouped %}
+            {% assign year_count = 0 %}
+            {% for meetup in year.items %}
+              {% assign year_count = year_count | plus: meetup.talks.size %}
+            {% endfor %}
+
+            <h3 class="talks-year">{{ year.name }} ({{ year_count }})</h3>
+
+            {% for meetup in year.items %}
+              {% for talk in meetup.talks %}
+              {% assign speakers = "" | split: ',' %}
+              {% for speaker in talk.speakers %}
+                {% assign speakers = speakers | push: site.data.people[speaker].name %}
+              {% endfor %}
+
+              {% capture search_text %}{{ talk.title }} {{ meetup.title }} {{ speakers | join: ' ' }} {{ talk.description }}{% endcapture %}
+
+              <div class="talk" data-search="{{ search_text | downcase | strip_html | strip_newlines }}">
+                <h3 id="{{ talk.title | slugify }}">
+                  <a href="{{ meetup.url }}#{{ talk.title | slugify }}">
+                    <span class="talk-title">{{ talk.title }}</span>
+                  </a>
+                  <p>
+                    {% for speaker in talk.speakers %}
+                      {% assign person = site.data.people[speaker] %}
+                      {% if person.github %}
+                        <img src="https://github.com/{{ person.github }}.png?size=30" alt="{{ person.name }}" style="border-radius: 50%; width: 30px; vertical-align: middle;"/>
+                      {% endif %}
+                      {{ person.name }}{% unless forloop.last %}, {% endunless %}
+                    {% endfor %}
+                  </p>
+                </h3>
+
+                <p>{{ talk.description }}</p>
+              </div>
+              {% endfor %}
+            {% endfor %}
+          {% endfor %}
+        </section>
+      </article>
+    </main>
+
+    {% include footer.html %}
+  </body>
+</html>

--- a/_layouts/talks.html
+++ b/_layouts/talks.html
@@ -35,20 +35,20 @@
               {% capture search_text %}{{ talk.title }} {{ meetup.title }} {{ speakers | join: ' ' }} {{ talk.description }}{% endcapture %}
 
               <div class="talk" data-search="{{ search_text | downcase | strip_html | strip_newlines }}">
-                <h3 id="{{ talk.title | slugify }}">
+                <h4 id="{{ talk.title | slugify }}">
                   <a href="{{ meetup.url }}#{{ talk.title | slugify }}">
                     <span class="talk-title">{{ talk.title }}</span>
                   </a>
-                  <p>
-                    {% for speaker in talk.speakers %}
-                      {% assign person = site.data.people[speaker] %}
-                      {% if person.github %}
-                        <img src="https://github.com/{{ person.github }}.png?size=30" alt="{{ person.name }}" style="border-radius: 50%; width: 30px; vertical-align: middle;"/>
-                      {% endif %}
-                      {{ person.name }}{% unless forloop.last %}, {% endunless %}
-                    {% endfor %}
-                  </p>
-                </h3>
+                </h4>
+                <p>
+                  {% for speaker in talk.speakers %}
+                    {% assign person = site.data.people[speaker] %}
+                    {% if person.github %}
+                      <img src="https://github.com/{{ person.github }}.png?size=30" alt="{{ person.name }}" loading="lazy" style="border-radius: 50%; width: 30px; vertical-align: middle;"/>
+                    {% endif %}
+                    {{ person.name }}{% unless forloop.last %}, {% endunless %}
+                  {% endfor %}
+                </p>
 
                 <p>{{ talk.description }}</p>
               </div>

--- a/_sass/meetups.scss
+++ b/_sass/meetups.scss
@@ -32,6 +32,23 @@
         display: none;
       }
     }
+
+    .meetup-event__search-link {
+      align-items: center;
+      display: inline-flex;
+      font-weight: bold;
+      margin-top: 1rem;
+
+      &, &:active, &:visited, &:focus, &:hover {
+        color: #FFC24D;
+        text-decoration: none;
+      }
+
+      img {
+        margin-left: 0.5rem;
+        filter: brightness(0) saturate(100%) invert(85%) sepia(35%) saturate(831%) hue-rotate(338deg) brightness(102%) contrast(101%);
+      }
+    }
   }
 
   .meetup-event__date_year {

--- a/_sass/meetups.scss
+++ b/_sass/meetups.scss
@@ -11,8 +11,8 @@
     @media (max-width: 425px) {
       padding: 2rem 1.5rem;
       display: flex;
-      justify-content: center;
-      align-items: center;
+      flex-direction: column;
+      align-items: flex-start;
     }
 
     h1 {

--- a/_sass/talks.scss
+++ b/_sass/talks.scss
@@ -1,0 +1,35 @@
+#view-talks {
+  .talks-year {
+    border-bottom: 2px solid #3967D1;
+    color: #3967D1;
+    font-size: 2rem;
+    font-weight: bold;
+    margin: 2rem 0 1.5rem;
+    padding-bottom: 0.5rem;
+  }
+
+  .talks-search {
+    background-color: #F6EEEC;
+    border: 3px solid #2E2E2E;
+    box-shadow: 6px 6px 0 #3967D1;
+    color: #3967D1;
+    font: 700 1rem 'Syncopate', sans-serif;
+    letter-spacing: 0.05em;
+    padding: 1rem 1.25rem;
+    text-transform: uppercase;
+    transition: box-shadow 0.15s ease, transform 0.15s ease;
+    width: 100%;
+
+    &::placeholder {
+      color: #3967D1;
+      opacity: 0.5;
+    }
+
+    &:focus {
+      box-shadow: 6px 6px 0 #FFC24D;
+      outline: none;
+      transform: translate(-2px, -2px);
+    }
+  }
+
+}

--- a/_sass/view.scss
+++ b/_sass/view.scss
@@ -1,4 +1,4 @@
-#view-meetup {
+.view {
   margin: 0 auto;
   width: 85%;
 

--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -1,3 +1,3 @@
 ---
 ---
-@import 'reset', 'application', 'header', 'nav', 'next_meetup', 'view_meetup', 'meetups', 'sponsors', 'footer';
+@import 'reset', 'application', 'header', 'nav', 'next_meetup', 'view', 'meetups', 'sponsors', 'footer', 'talks';

--- a/assets/js/talks.js
+++ b/assets/js/talks.js
@@ -1,0 +1,15 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const input = document.querySelector("#talks-search");
+  if (!input) return;
+
+  const talks = document.querySelectorAll(".talk");
+
+  input.addEventListener("input", () => {
+    const query = input.value.trim().toLowerCase();
+
+    talks.forEach((talk) => {
+      const haystack = talk.dataset.search || "";
+      talk.hidden = query && !haystack.includes(query);
+    });
+  });
+});

--- a/talks.html
+++ b/talks.html
@@ -1,0 +1,4 @@
+---
+layout: talks
+permalink: /charlas/
+---


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                   
Adds a dedicated Talks page that lists all talks across meetups in a timeline view, with client-side search to filter by title or speaker.                                                                                                                                   
                                                                                                                                                                                                                                                                          
## Changes                                                                                                                                                                                                                                                                   
- New `/talks` page (`talks.html` + `_layouts/talks.html`)                                                                                                                                                                                                                   
- Search input with JS filter (`assets/js/talks.js`)                                                                                                                                                                                                                         
- Link to Talks in footer and meetups section                                                                                                                                                                                                                                
- Renamed `view_meetup.scss` → `view.scss` and added `talks.scss`                                                                                                                                                                                                            

## Screenshots

### Home
<img width="1728" height="1084" alt="Screenshot 2026-04-30 at 11 23 01 AM" src="https://github.com/user-attachments/assets/0063a501-c0ff-4bc2-b494-0497474de069" />

### Talks
<img width="1728" height="1084" alt="Screenshot 2026-04-30 at 11 23 04 AM" src="https://github.com/user-attachments/assets/755cd9ef-12ba-4dc9-8b54-4de431a36864" />
