### PR TITLE
Feat: add community stats view

### DIFF
--- a/_includes/default_header.html
+++ b/_includes/default_header.html
@@ -16,6 +16,7 @@
         </a>
       {% endfor %}
       <a href="/community">Community<img src='/assets/images/arrow.svg' aria-hidden="true" focuseable="false"/></a>
+      <a href="/stats">Stats<img src='/assets/images/arrow.svg' aria-hidden="true" focuseable="false"/></a>
     </div>
   </div>
 </header>

--- a/_layouts/stats.html
+++ b/_layouts/stats.html
@@ -1,0 +1,208 @@
+<!DOCTYPE html>
+<html lang="en">
+  {% include head.html %}
+
+  <body>
+    {% include nav.html %}
+
+    <main>
+      <article id="view-stats" class="view">
+        <section>
+          <h2>Stats</h2>
+          <p class="stats-subtitle">The Ruby UY community in numbers</p>
+        </section>
+
+        {% comment %} Base data {% endcomment %}
+        {% assign projects = site.data.community.projects %}
+        {% assign meetups = site.meetups | sort: "date" %}
+
+        {% comment %} Talks {% endcomment %}
+        {% assign all_talks = meetups | flat_map: "talks" %}
+        {% assign all_talks_count = all_talks | size %}
+
+        {% comment %} Stamps {% endcomment %}
+        {% assign total_stars = projects | sum_by: "stars" %}
+        {% assign unique_authors = projects | map: "github_user" | uniq %}
+
+        {% comment %} Meetups {% endcomment %}
+        {% assign meetups_by_year = meetups | group_by_exp: "meetup", "meetup.date | date: '%Y'" %}
+        {% assign top_hosts_by_meetups = meetups | group_by: "host" | sort: "size" | reverse %}
+
+        {% comment %} Talks rankings {% endcomment %}
+        {% assign hosts_by_talk = "" | split: "" %}
+        {% for meetup in meetups %}
+          {% for talk in meetup.talks %}
+            {% assign hosts_by_talk = hosts_by_talk | push: meetup.host %}
+          {% endfor %}
+        {% endfor %}
+        {% assign top_hosts = hosts_by_talk | group_by_exp: "host_slug", "host_slug" | sort: "size" | reverse | slice: 0, 5 %}
+        {% assign all_speakers = all_talks | flat_map: "speakers" %}
+        {% assign grouped_speakers = all_speakers | group_by_exp: "speaker_id", "speaker_id" | sort: "size" | reverse | slice: 0, 5 %}
+
+        {% comment %} Projects rankings {% endcomment %}
+        {% assign top_projects = projects | sort: "stars" | reverse | slice: 0, 5 %}
+        {% assign top_contributors_by_count = projects | group_by: "github_user" | sort: "size" | reverse %}
+        {% assign all_topics = projects | flat_map: "topics" | compact %}
+        {% assign top_topics = all_topics | group_by_exp: "item", "item" | sort: "size" | reverse | slice: 0, 8 %}
+
+        <section class="stats-stamps">
+          <div class="stats-stamp stats-stamp--1">
+            <div class="stats-stamp-num">{{ meetups.size }}</div>
+            <div class="stats-stamp-label">Meetups</div>
+          </div>
+          <div class="stats-stamp stats-stamp--2">
+            <div class="stats-stamp-num">{{ all_talks_count }}</div>
+            <div class="stats-stamp-label">Talks</div>
+          </div>
+          <div class="stats-stamp stats-stamp--3">
+            <div class="stats-stamp-num">{{ site.data.people.size }}</div>
+            <div class="stats-stamp-label">Members</div>
+          </div>
+          <div class="stats-stamp stats-stamp--4">
+            <div class="stats-stamp-num">{{ projects.size }}</div>
+            <div class="stats-stamp-label">Projects</div>
+          </div>
+          <div class="stats-stamp stats-stamp--5">
+            <div class="stats-stamp-num">{{ total_stars }}</div>
+            <div class="stats-stamp-label">Stars</div>
+          </div>
+          <div class="stats-stamp stats-stamp--6">
+            <div class="stats-stamp-num">{{ unique_authors.size }}</div>
+            <div class="stats-stamp-label">Authors</div>
+          </div>
+        </section>
+
+        <section>
+          <h3>Meetups</h3>
+
+          <h4 class="stats-subheading">Per year — each square = one meetup</h4>
+          <div class="stats-visualcount">
+            {% for year in meetups_by_year %}
+              {% assign year_meetup_count = year.items.size %}
+              <div class="stats-visualcount-row">
+                <span class="stats-visualcount-year">{{ year.name }}</span>
+                <div class="stats-visualcount-blocks">
+                  {% for meetup in year.items %}
+                    <a href="{{ meetup.url }}" class="stats-block" title="{{ meetup.host }} — {{ meetup.date | date: '%b %Y' }}"></a>
+                  {% endfor %}
+                </div>
+                <span class="stats-visualcount-total">{{ year_meetup_count }}</span>
+              </div>
+            {% endfor %}
+          </div>
+
+          <h4 class="stats-subheading">Top hosts (by meetups)</h4>
+          <ol class="stats-ranking">
+            {% for host_group in top_hosts_by_meetups limit: 5 %}
+              {% assign company = site.data.companies[host_group.name] %}
+              <li><strong>{{ company.name | default: host_group.name }}</strong> <span class="stats-value">{{ host_group.size }} meetups</span></li>
+            {% endfor %}
+          </ol>
+        </section>
+
+        <section>
+          <h3>Talks</h3>
+
+          <h4 class="stats-subheading">Per year — each dot = one talk</h4>
+          <div class="stats-visualcount">
+            {% for year in meetups_by_year %}
+              {% assign year_talk_count = year.items | flat_map: "talks" | size %}
+              <div class="stats-visualcount-row">
+                <span class="stats-visualcount-year">{{ year.name }}</span>
+                <div class="stats-visualcount-blocks">
+                  {% for meetup in year.items %}
+                    {% for talk in meetup.talks %}
+                      <a href="{{ meetup.url }}#{{ talk.title | slugify }}" class="stats-dot" title="{{ talk.title }}"></a>
+                    {% endfor %}
+                  {% endfor %}
+                </div>
+                <span class="stats-visualcount-total">{{ year_talk_count }}</span>
+              </div>
+            {% endfor %}
+          </div>
+
+          <h4 class="stats-subheading">Top hosting companies (by talks featured)</h4>
+          <ol class="stats-ranking">
+            {% for host in top_hosts %}
+              {% assign company = site.data.companies[host.name] %}
+              <li>
+                <strong>{{ company.name | default: host.name }}</strong> 
+                <span class="stats-value">{{ host.size }} talks</span>
+              </li>
+            {% endfor %}
+          </ol>
+
+          <h4 class="stats-subheading">Most active speakers</h4>
+          <ol class="stats-ranking">
+            {% for group in grouped_speakers %}
+              {% assign person = site.data.people[group.name] %}
+              <li><strong>{{ person.name | default: group.name }}</strong> <span class="stats-value">{{ group.size }} talks</span></li>
+            {% endfor %}
+          </ol>
+        </section>
+
+        <section>
+          <h3>Projects</h3>
+          <div class="stats-hero">
+            <div class="stats-hero-number">{{ total_stars }}</div>
+            <div class="stats-hero-label">GitHub stars across our community's projects</div>
+          </div>
+
+          <h4 class="stats-subheading">Top 5 by stars</h4>
+          <ol class="stats-ranking">
+            {% for project in top_projects %}
+              <li>
+                <a href="{{ project.url }}" target="_blank" rel="noopener"><strong>{{ project.name }}</strong></a>
+                <span class="stats-author">@{{ project.github_user }}</span>
+                <span class="stats-value">★ {{ project.stars }}</span>
+              </li>
+            {% endfor %}
+          </ol>
+
+          <h4 class="stats-subheading">Top contributors (by Ruby/Rails project count)</h4>
+          <table class="stats-table">
+            <thead><tr><th>Author</th><th>Projects</th><th>Total stars</th></tr></thead>
+            <tbody>
+              {% for contributor in top_contributors_by_count limit: 5 %}
+                <tr>
+                  <td>@{{ contributor.name }}</td>
+                  <td>{{ contributor.size }}</td>
+                  <td>{{ contributor.items | sum_by: "stars" }}</td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+
+          <h4 class="stats-subheading">Most popular topics</h4>
+          <div class="stats-topics">
+            {% for entry in top_topics %}
+              <span class="stats-topic">{{ entry.name }} <em>{{ entry.size }}</em></span>
+            {% endfor %}
+          </div>
+        </section>
+
+        <section>
+          <h3>Here's your receipt</h3>
+          <div class="stats-receipt">
+            <div class="stats-receipt-header">
+              <div>RUBY UY</div>
+              <div>COMMUNITY RECEIPT</div>
+              <div>SINCE 2022 — {{ meetups.size }} EVENTS HOSTED</div>
+            </div>
+            <div class="stats-receipt-row"><span>Meetups hosted</span><span>{{ meetups.size }}</span></div>
+            <div class="stats-receipt-row"><span>Talks delivered</span><span>{{ all_talks_count }}</span></div>
+            <div class="stats-receipt-row"><span>Active members</span><span>{{ site.data.people.size }}</span></div>
+            <div class="stats-receipt-row"><span>Open source projects</span><span>{{ projects.size }}</span></div>
+            <div class="stats-receipt-row"><span>Total GitHub stars</span><span>{{ total_stars }}</span></div>
+            <div class="stats-receipt-row"><span>Unique authors</span><span>{{ unique_authors.size }}</span></div>
+            <div class="stats-receipt-divider">— — — — — — — — — —</div>
+            <div class="stats-receipt-row stats-receipt-total"><span>TOTAL IMPACT</span><span>∞</span></div>
+            <div class="stats-receipt-footer">THANK YOU FOR BEING PART OF THE COMMUNITY</div>
+          </div>
+        </section>
+      </article>
+    </main>
+
+    {% include footer.html %}
+  </body>
+</html>

--- a/_plugins/filters.rb
+++ b/_plugins/filters.rb
@@ -16,6 +16,15 @@ module CustomFilters
   def image_asset(filename)
     "/assets/images/#{filename}"
   end
+
+  def flat_map(array, key)
+    Array(array).flat_map { |item| item[key] || [] }
+  end
+
+  def sum_by(array, key)
+    Array(array).sum { |item| item[key].to_i }
+  end
+
 end
 
 Liquid::Template.register_filter(CustomFilters)

--- a/_sass/stats.scss
+++ b/_sass/stats.scss
@@ -1,0 +1,372 @@
+#view-stats {
+  h2 {
+    overflow-wrap: break-word;
+
+    @media (max-width: 480px) {
+      font-size: 1.75rem;
+    }
+  }
+
+  .stats-subtitle {
+    color: #2E2E2E;
+    margin-bottom: 2rem;
+    opacity: 0.7;
+  }
+
+  h3 {
+    border-bottom: 2px solid #3967D1;
+    color: #3967D1;
+    font-size: 1.5rem;
+    margin: 3rem 0 1.5rem;
+    padding-bottom: 0.5rem;
+  }
+
+  .stats-subheading {
+    color: #2E2E2E;
+    font-size: 0.85rem;
+    font-weight: bold;
+    letter-spacing: 0.05em;
+    margin: 2rem 0 0.75rem;
+    opacity: 0.75;
+    text-transform: uppercase;
+  }
+
+  .stats-ranking {
+    counter-reset: rank;
+    list-style: none;
+    padding: 0;
+
+    li {
+      align-items: center;
+      border: 3px solid #2E2E2E;
+      box-shadow: 4px 4px 0 #2E2E2E;
+      counter-increment: rank;
+      display: flex;
+      gap: 0.75rem;
+      margin: 0.75rem 0;
+      padding: 1rem 1.25rem;
+      transition: box-shadow 0.15s ease, transform 0.15s ease;
+
+      &:hover {
+        box-shadow: 6px 6px 0 #3967D1;
+        transform: translate(-2px, -2px);
+      }
+
+      &::before {
+        align-items: center;
+        background-color: #FFC24D;
+        border: 2px solid #2E2E2E;
+        color: #2E2E2E;
+        content: counter(rank);
+        display: flex;
+        flex: none;
+        font: 700 0.9rem 'Syncopate', sans-serif;
+        height: 2rem;
+        justify-content: center;
+        line-height: 1;
+        width: 2rem;
+      }
+
+      strong {
+        color: #2E2E2E;
+      }
+
+      a {
+        color: #2E2E2E;
+        text-decoration: none;
+
+        &:hover { color: #3967D1; }
+      }
+    }
+  }
+
+  .stats-author {
+    color: #2E2E2E;
+    font-size: 0.85rem;
+    opacity: 0.6;
+  }
+
+  .stats-value,
+  .stats-visualcount-total {
+    background-color: #FFC24D;
+    border: 2px solid #2E2E2E;
+    color: #2E2E2E;
+    font: 700 0.85rem 'Syncopate', sans-serif;
+    margin-left: auto;
+    padding: 0.25rem 0.5rem;
+  }
+
+  .stats-value { white-space: nowrap; }
+
+  .stats-table {
+    border: 3px solid #2E2E2E;
+    border-collapse: collapse;
+    box-shadow: 4px 4px 0 #2E2E2E;
+    margin: 1rem 0;
+    width: 100%;
+
+    th, td {
+      border-bottom: 2px solid #2E2E2E;
+      padding: 0.85rem 1rem;
+      text-align: left;
+    }
+
+    tr:last-child td { border-bottom: none; }
+
+    th {
+      background-color: #3967D1;
+      color: #fff;
+      font-size: 0.75rem;
+      font-weight: bold;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+    }
+
+    td {
+      color: #2E2E2E;
+    }
+
+    td:first-child {
+      font-weight: bold;
+    }
+
+    td:not(:first-child) {
+      font-variant-numeric: tabular-nums;
+    }
+  }
+
+  .stats-topics {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    padding: 1rem 0;
+  }
+
+  .stats-hero {
+    background-color: #3967D1;
+    border: 3px solid #2E2E2E;
+    box-shadow: 8px 8px 0 #2E2E2E;
+    color: #fff;
+    padding: 3rem 2rem;
+    text-align: center;
+    transition: box-shadow 0.15s ease, transform 0.15s ease;
+
+    &:hover {
+      box-shadow: 12px 12px 0 #FFC24D;
+      transform: translate(-4px, -4px);
+    }
+  }
+
+  .stats-hero-number {
+    font: 700 6rem 'Syncopate', sans-serif;
+    line-height: 1;
+
+    @media (max-width: 480px) {
+      font-size: 3.5rem;
+    }
+  }
+
+  .stats-hero-label {
+    font-size: 0.9rem;
+    letter-spacing: 0.05em;
+    margin-top: 1rem;
+    opacity: 0.85;
+    text-transform: uppercase;
+  }
+
+  .stats-visualcount {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    margin: 1rem 0;
+  }
+
+  .stats-visualcount-row {
+    align-items: center;
+    display: flex;
+    gap: 1rem;
+  }
+
+  .stats-visualcount-year {
+    color: #2E2E2E;
+    font: 700 0.85rem 'Syncopate', sans-serif;
+    letter-spacing: 0.05em;
+    width: 3rem;
+  }
+
+  .stats-visualcount-blocks {
+    display: flex;
+    flex: 1;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+  }
+
+  .stats-visualcount-total {
+    min-width: 2.25rem;
+    text-align: center;
+  }
+
+  .stats-block {
+    background-color: #FFC24D;
+    border: 2px solid #2E2E2E;
+    box-shadow: 2px 2px 0 #2E2E2E;
+    display: block;
+    height: 1.5rem;
+    text-decoration: none;
+    transition: transform 0.1s ease, background-color 0.1s ease;
+    width: 1.5rem;
+
+    &:hover {
+      background-color: #3967D1;
+      transform: translate(-1px, -1px);
+    }
+  }
+
+  .stats-dot {
+    background-color: #3967D1;
+    border: 2px solid #2E2E2E;
+    display: block;
+    height: 0.85rem;
+    text-decoration: none;
+    transition: transform 0.1s ease, background-color 0.1s ease;
+    width: 0.85rem;
+
+    &:hover {
+      background-color: #FFC24D;
+      transform: scale(1.4);
+    }
+  }
+
+  .stats-stamps {
+    align-items: center;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    gap: 1rem;
+    justify-content: space-between;
+    margin: 2rem 0;
+    overflow-x: auto;
+    padding: 2rem 0.5rem;
+
+    @media (max-width: 720px) {
+      flex-wrap: wrap;
+      justify-content: center;
+      gap: 0.75rem 1.25rem;
+    }
+  }
+
+  .stats-stamp {
+    background-color: #F6EEEC;
+    border: 3px solid #2E2E2E;
+    box-shadow: 4px 4px 0 #2E2E2E;
+    flex: 0 0 auto;
+    padding: 1rem 1.25rem;
+    text-align: center;
+    transition: box-shadow 0.15s ease, transform 0.15s ease;
+
+    &:hover {
+      box-shadow: 8px 8px 0 #3967D1;
+      transform: rotate(0) translate(-2px, -2px);
+      z-index: 2;
+    }
+
+    &--1 { transform: rotate(-3deg); background-color: #FFC24D; }
+    &--2 { transform: rotate(2deg);  background-color: #3967D1; color: #fff; }
+    &--3 { transform: rotate(-1deg); }
+    &--4 { transform: rotate(4deg);  background-color: #FFC24D; }
+    &--5 { transform: rotate(-2deg); background-color: #3967D1; color: #fff; }
+    &--6 { transform: rotate(3deg); }
+  }
+
+  .stats-stamp-num {
+    font: 700 2rem 'Syncopate', sans-serif;
+    line-height: 1;
+  }
+
+  .stats-stamp-label {
+    font-size: 0.7rem;
+    letter-spacing: 0.05em;
+    margin-top: 0.5rem;
+    text-transform: uppercase;
+  }
+
+  .stats-receipt {
+    background-color: #fff;
+    border: 3px solid #2E2E2E;
+    box-shadow: 4px 4px 0 #2E2E2E;
+    font-family: 'Courier New', monospace;
+    margin: 1rem auto;
+    max-width: 24rem;
+    padding: 2rem 1.75rem;
+  }
+
+  .stats-receipt-header {
+    border-bottom: 2px dashed #2E2E2E;
+    margin-bottom: 1rem;
+    padding-bottom: 1rem;
+    text-align: center;
+
+    div:first-child {
+      font: 700 1.25rem 'Syncopate', sans-serif;
+      letter-spacing: 0.1em;
+    }
+
+    div {
+      font-size: 0.75rem;
+      margin-top: 0.25rem;
+      text-transform: uppercase;
+    }
+  }
+
+  .stats-receipt-row {
+    display: flex;
+    font-size: 0.85rem;
+    justify-content: space-between;
+    padding: 0.4rem 0;
+
+    span:last-child {
+      font-weight: bold;
+    }
+  }
+
+  .stats-receipt-divider {
+    color: #2E2E2E;
+    font-size: 0.85rem;
+    letter-spacing: 0.2em;
+    margin: 0.5rem 0;
+    text-align: center;
+  }
+
+  .stats-receipt-total {
+    font-size: 1rem;
+    font-weight: bold;
+    text-transform: uppercase;
+  }
+
+  .stats-receipt-footer {
+    border-top: 2px dashed #2E2E2E;
+    font-size: 0.7rem;
+    letter-spacing: 0.05em;
+    margin-top: 1rem;
+    padding-top: 1rem;
+    text-align: center;
+    text-transform: uppercase;
+  }
+
+  .stats-topic {
+    background-color: #F6EEEC;
+    border: 2px solid #2E2E2E;
+    color: #2E2E2E;
+    font-size: 0.75rem;
+    letter-spacing: 0.05em;
+    padding: 0.4rem 0.7rem;
+    text-transform: uppercase;
+
+    em {
+      color: #3967D1;
+      font-style: normal;
+      font-weight: bold;
+      margin-left: 0.4rem;
+    }
+  }
+}

--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -1,3 +1,3 @@
 ---
 ---
-@import 'reset', 'application', 'header', 'nav', 'next_meetup', 'view', 'meetups', 'sponsors', 'footer', 'talks', 'community', 'project-card';
+@import 'reset', 'application', 'header', 'nav', 'next_meetup', 'view', 'meetups', 'sponsors', 'footer', 'talks', 'community', 'project-card', 'stats';

--- a/stats.html
+++ b/stats.html
@@ -1,0 +1,4 @@
+---
+layout: stats
+permalink: /stats/
+---


### PR DESCRIPTION
## Description

Adds a `/stats` page with community metrics: meetups, talks, members, projects, GitHub stars, and authors. Includes per-year visualizations, host/speaker/project rankings, and a receipt section at the bottom.

Data is sourced from the existing Jekyll collections and data files (`_meetups/`, `_data/people.yml`, `_data/community.yml`, `_data/companies.yml`), so all stats auto-update as new meetup files or data entries are added. Added `flat_map` and `sum_by` custom Liquid filters to support the aggregation logic.


## Screenshots
<img width="1728" height="1084" alt="Screenshot 2026-05-06 at 4 20 46 PM" src="https://github.com/user-attachments/assets/3b020491-dea4-4ec2-ba99-ec974cba4374" />
<img width="1728" height="1084" alt="Screenshot 2026-05-06 at 4 20 50 PM" src="https://github.com/user-attachments/assets/b8e438a0-a25c-4132-8eb8-15ef4f4c9ee9" />
<img width="1728" height="1084" alt="Screenshot 2026-05-06 at 4 20 53 PM" src="https://github.com/user-attachments/assets/3e437d6a-56a9-4517-8a71-cf27add8c23d" />
<img width="1728" height="1084" alt="Screenshot 2026-05-06 at 4 20 56 PM" src="https://github.com/user-attachments/assets/a0b739d5-15a1-4b14-8dc1-813f451012e8" />
<img width="1728" height="1084" alt="Screenshot 2026-05-06 at 4 21 01 PM" src="https://github.com/user-attachments/assets/8d86fc73-aafa-47de-8f5e-8a7d9fca64a2" />
