### PR TITLE
feat: add /primera-vez/ FAQ page for first-time attendees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ _site
 .jekyll-metadata
 vendor
 .DS_Store
+docs/superpowers/

--- a/_includes/default_header.html
+++ b/_includes/default_header.html
@@ -16,6 +16,7 @@
         </a>
       {% endfor %}
       <a href="/community">Community<img src='/assets/images/arrow.svg' aria-hidden="true" focuseable="false"/></a>
+      <a href="/primera-vez/">Primera vez<img src='/assets/images/arrow.svg' aria-hidden="true" focuseable="false"/></a>
     </div>
   </div>
 </header>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,8 +1,8 @@
 <head>
-  <title>Ruby UY</title>
+  <title>{{ page.title | default: "Ruby UY" }}</title>
   <meta charset='utf-8' />
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="Sitio de la comunidad de Ruby en Uruguay">
+  <meta name="description" content="{{ page.description | default: 'Sitio de la comunidad de Ruby en Uruguay' }}">
   <meta name="view-transition" content="same-origin" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/_layouts/primera-vez.html
+++ b/_layouts/primera-vez.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="es">
+  {% include head.html %}
+
+  <body>
+    <nav class="pv-breadcrumb" aria-label="breadcrumb">
+      <div class="pv-breadcrumb__inner">
+        <ol class="pv-breadcrumb__trail">
+          <li><a href="/">Ruby UY</a></li>
+          <li><span class="sep" aria-hidden="true">›</span></li>
+          <li><span class="pv-breadcrumb__current" aria-current="page">Primera vez</span></li>
+        </ol>
+      </div>
+    </nav>
+
+    <main>
+      <article id="view-primera-vez">
+        {{ content }}
+      </article>
+    </main>
+
+    {% include footer.html %}
+  </body>
+</html>

--- a/_sass/primera-vez.scss
+++ b/_sass/primera-vez.scss
@@ -1,0 +1,104 @@
+.pv-breadcrumb {
+  background: #3967D1;
+  width: 100%;
+
+  .pv-breadcrumb__inner {
+    align-items: center;
+    display: flex;
+    height: 44px;
+    padding: 0 2rem;
+  }
+
+  .pv-breadcrumb__trail {
+    align-items: center;
+    display: flex;
+    font-size: 0.75rem;
+    font-weight: 700;
+    gap: 0.75rem;
+    letter-spacing: 0.08em;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+
+    a {
+      color: #fff;
+      text-decoration: none;
+
+      &:hover { color: #fcc24e; }
+    }
+
+    .sep { color: rgba(255, 255, 255, 0.4); }
+  }
+
+  .pv-breadcrumb__current { color: #fcc24e; }
+
+  @media (max-width: 768px) {
+    .pv-breadcrumb__inner {
+      height: auto;
+      padding: 0.75rem 1.25rem;
+    }
+  }
+}
+
+#view-primera-vez {
+  background: #F6EEEC;
+  margin: 0 auto;
+  max-width: 760px;
+  padding: 2.5rem 2rem 3rem;
+  width: 100%;
+
+  @media (max-width: 768px) {
+    padding: 2rem 1.25rem 2.5rem;
+  }
+
+  @media (max-width: 425px) {
+    padding: 1.5rem 1rem 2rem;
+  }
+}
+
+.pv-title {
+  color: #3967D1;
+  font: 700 clamp(1.5rem, 4vw, 2.25rem)/1.05 'Syncopate', sans-serif;
+  letter-spacing: 0.04em;
+  margin-bottom: 0.5rem;
+}
+
+.pv-subtitle {
+  color: rgba(46, 46, 46, 0.55);
+  font-family: 'DM Sans', system-ui, sans-serif;
+  font-size: 1rem;
+  line-height: 1.5;
+  margin-bottom: 2.5rem;
+}
+
+.pv-faq {
+  display: flex;
+  flex-direction: column;
+}
+
+.pv-faq__item {
+  border-bottom: 1px solid rgba(46, 46, 46, 0.1);
+  border-left: 3px solid #fcc24e;
+  margin-bottom: 1rem;
+  padding: 0 0 1rem 1.25rem;
+
+  &:last-child {
+    border-bottom: none;
+    margin-bottom: 0;
+  }
+}
+
+.pv-faq__q {
+  color: #3967D1;
+  font: 700 0.8rem 'Syncopate', sans-serif;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.5rem;
+  text-transform: uppercase;
+}
+
+.pv-faq__a {
+  color: rgba(46, 46, 46, 0.72);
+  font-family: 'DM Sans', system-ui, sans-serif;
+  font-size: 0.975rem;
+  line-height: 1.65;
+}

--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -1,3 +1,3 @@
 ---
 ---
-@import 'reset', 'application', 'header', 'nav', 'next_meetup', 'view', 'meetups', 'sponsors', 'footer', 'talks', 'community', 'project-card';
+@import 'reset', 'application', 'header', 'nav', 'next_meetup', 'view', 'meetups', 'sponsors', 'footer', 'talks', 'community', 'project-card', 'primera-vez';

--- a/primera-vez/index.html
+++ b/primera-vez/index.html
@@ -1,0 +1,36 @@
+---
+layout: primera-vez
+permalink: /primera-vez/
+title: "Primera vez — Ruby UY"
+description: "Respondemos las dudas más frecuentes antes de venir a tu primera meetup de Ruby UY."
+---
+
+<h1 class="pv-title">¿ES TU PRIMERA MEETUP?</h1>
+<p class="pv-subtitle">Todo lo que necesitás saber antes de venir</p>
+
+<dl class="pv-faq">
+  <div class="pv-faq__item">
+    <dt class="pv-faq__q">¿Tengo que saber Ruby?</dt>
+    <dd class="pv-faq__a">No necesariamente, pero las charlas suelen ser tecnicas y orientadas a desarrolladores.</dd>
+  </div>
+  <div class="pv-faq__item">
+    <dt class="pv-faq__q">¿Es gratis?</dt>
+    <dd class="pv-faq__a">Sí, completamente gratis y te anotas en meetup.com</dd>
+  </div>
+  <div class="pv-faq__item">
+    <dt class="pv-faq__q">¿En qué idioma son las charlas?</dt>
+    <dd class="pv-faq__a">En español. A veces hay charlas en inglés, pero siempre se aclara con anticipación.</dd>
+  </div>
+  <div class="pv-faq__item">
+    <dt class="pv-faq__q">¿Puedo ir solo/a?</dt>
+    <dd class="pv-faq__a">Si! La comunidad es abierta y amigable, no hace falta conocer a nadie de antemano.</dd>
+  </div>
+  <div class="pv-faq__item">
+    <dt class="pv-faq__q">¿Hay comida?</dt>
+    <dd class="pv-faq__a">Sí. La empresa que hostea la meetup y ofrece comida y bebidas.</dd>
+  </div>
+  <div class="pv-faq__item">
+    <dt class="pv-faq__q">¿A qué hora conviene llegar?</dt>
+    <dd class="pv-faq__a">Las meetups arrancan puntual a las 19 hs.</dd>
+  </div>
+</dl>


### PR DESCRIPTION
## Summary

- Adds `/primera-vez/` page answering 6 common questions for first-time meetup attendees (¿Tengo que saber Ruby? / ¿Es gratis? / ¿En qué idioma? / ¿Puedo ir solo/a? / ¿Hay comida? / ¿A qué hora llegar?)
- Adds "Primera vez" chip to the homepage hero "Sé parte_" band linking to the new page
- Updates `_includes/head.html` to support per-page `title` and `description` front-matter variables (with defaults, no regression on existing pages)

<img width="1688" height="1014" alt="image" src="https://github.com/user-attachments/assets/1518e72f-71c4-4121-95db-a4de28b7d0cb" />

## Test Plan

- [ ] Navigate to `/primera-vez/` — page renders with Ruby logo nav, blue breadcrumb, and 6 FAQ items with yellow left-border accent
- [ ] Browser tab reads "Primera vez — Ruby UY"
- [ ] Homepage tab still reads "Ruby UY"
- [ ] "Primera vez" chip appears in the green "Sé parte_" band on the homepage and links to `/primera-vez/`
- [ ] Responsive at 425px and 768px — no horizontal scroll, readable padding