### PR TITLE
FIX: layout for stats & community view

### DIFF
--- a/_sass/view.scss
+++ b/_sass/view.scss
@@ -9,6 +9,72 @@ $vm-white: #ffffff;
 $vm-container: 1600px;
 $vm-pad-x: 4rem;
 
+.view {
+  margin: 0 auto;
+  width: 85%;
+
+  @media (min-width: 1024px) {
+    width: 65%;
+  }
+
+  section {
+    width: 100%;
+    margin-top: 1.25rem;
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 3rem;
+
+    &:first-child {
+      margin-top: 4rem;
+    }
+  }
+
+  a {
+    font-size: 1.25rem;
+  }
+
+  h2 {
+    margin-bottom: 1rem;
+    font-weight: bold;
+    font-size: 2.5rem;
+  }
+
+  h3 {
+    margin-bottom: 1rem;
+    font-size: 1.25rem;
+    overflow-wrap: break-word;
+  }
+
+  span {
+    font-weight: bold;
+  }
+
+  .keep-aspect-ratio {
+    position: relative;
+    width: 100%;
+    padding-top: 56.25%;
+    margin-bottom: 1.25rem;
+
+    iframe {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+    }
+  }
+
+  .talk {
+    margin-bottom: 2rem;
+
+    h3 {
+      a {
+        font-size: 1.75rem;
+      }
+    }
+  }
+}
+
 .page-meetup .meetup__default > div:first-child {
   display: none;
 }


### PR DESCRIPTION
## Summary
- Restores the `.view` container styles (width, margins, section/heading spacing) in `_sass/view.scss`
- The meetup redesign (#146) replaced `.view` with `#view-meetup`-scoped rules and accidentally deleted the shared class, so `/stats/`, `/community/`, `/talks/` and `404.html` rendered full-width with no padding

## Test plan
- [x] `bundle exec jekyll s` locally, verified `/stats/` and `/community/` render with proper container width/margins again