### PR TITLE
Community call: shared skills for the Rails community

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,6 +28,9 @@ collections:
   meetups:
     output: true
     permalink: /meetups/:year-:month-:day/:title
+  skills:
+    output: true
+    permalink: /skills/:name/
 
 defaults:
   - scope:
@@ -69,3 +72,10 @@ defaults:
     values:
       description: "Detalle de meetup de Ruby UY con charlas, speakers y recursos de la comunidad Ruby en Uruguay."
       keywords: "meetup ruby uruguay, charlas ruby, comunidad ruby uruguay"
+  - scope:
+      path: ""
+      type: "skills"
+    values:
+      layout: skill
+      page_scripts: [skill]
+      keywords: "skills ruby on rails, claude code skills, agentes ia ruby, comunidad ruby uruguay"

--- a/_data/skills.yml
+++ b/_data/skills.yml
@@ -1,0 +1,14 @@
+# Community-made skills for coding agents (Claude Code, etc.) focused on Ruby on Rails.
+# Skills belong to the community — they are not attributed to a single author.
+#
+# To add one: drop a SKILL.md in _skills/<name>.md and add its entry here.
+
+last_updated: 2026-08-14
+
+skills:
+  - name: rspec-tests-for-rails
+    category: Tests
+    type: rule
+    description: Rules for writing fast, maintainable RSpec specs in Rails — build_stubbed over build/create, let over before, avoiding N+1s in specs, memoizing the subject.
+    url: /skills/rspec-tests-for-rails/
+    topics: [rspec, testing, factorybot]

--- a/_includes/default_header.html
+++ b/_includes/default_header.html
@@ -18,6 +18,7 @@
       <a href="/community">Community<img src='/assets/images/arrow.svg' aria-hidden="true" focuseable="false"/></a>
       <a href="/primera-vez/">Primera vez<img src='/assets/images/arrow.svg' aria-hidden="true" focuseable="false"/></a>
       <a href="/stats">Stats<img src='/assets/images/arrow.svg' aria-hidden="true" focuseable="false"/></a>
+      <a href="/skills/">Skills<img src='/assets/images/arrow.svg' aria-hidden="true" focuseable="false"/></a>
     </div>
   </div>
 </header>

--- a/_includes/skill_card.html
+++ b/_includes/skill_card.html
@@ -1,0 +1,18 @@
+<div class="skill" data-search="{{ search_text | downcase | strip_html | strip_newlines }}">
+  <h4>
+    <a href="{{ skill.url }}">{{ skill.name }}</a>
+    <span class="skill-type skill-type-{{ skill.type | default: "skill" }}">{{ skill.type | default: "skill" }}s</span>
+  </h4>
+
+  {% if skill.description != "" %}
+    <p class="skill-description">{{ skill.description }}</p>
+  {% endif %}
+
+  {% if skill.topics.size > 0 %}
+    <div class="skill-topics">
+      {% for topic in skill.topics limit: 4 %}
+        <span class="skill-topic">{{ topic }}</span>
+      {% endfor %}
+    </div>
+  {% endif %}
+</div>

--- a/_layouts/skill.html
+++ b/_layouts/skill.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+  {% include head.html %}
+
+  <body>
+    {% include nav.html %}
+
+    <main>
+      <article id="view-skill" class="view">
+        {% comment %} Catalog metadata lives only in _data/skills.yml {% endcomment %}
+        {% assign skill = site.data.skills.skills | where: "url", page.url | first %}
+
+        <section>
+          <a href="/skills/" class="skill-back">&larr; Skills</a>
+          <h2>{{ skill.name }}</h2>
+          <p class="skill-detail-description">{{ skill.description }}</p>
+        </section>
+
+        <section>
+          <div class="skill-toolbar">
+            <div class="skill-tabs">
+              <button class="skill-tab active" data-view="markdown" type="button">Markdown</button>
+              <button class="skill-tab" data-view="raw" type="button">Raw</button>
+            </div>
+            <button id="skill-copy" class="skill-copy-btn" type="button">Copy</button>
+          </div>
+
+          {% comment %} Rendered by Jekyll; the raw file is re-read below for the copy button {% endcomment %}
+          <div id="skill-markdown" class="skill-markdown">{{ content }}</div>
+
+          {% capture skill_source %}{% include_relative {{ page.slug }}.md %}{% endcapture %}
+          <pre id="skill-source" class="skill-raw" hidden>{{ skill_source | escape }}</pre>
+        </section>
+      </article>
+    </main>
+
+    {% include footer.html %}
+  </body>
+</html>

--- a/_layouts/skills.html
+++ b/_layouts/skills.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+  {% include head.html %}
+
+  <body>
+    {% include nav.html %}
+
+    <main>
+      <article id="view-skills" class="view">
+        <section>
+          <h2>Skills &amp; Rules</h2>
+          <p class="skills-subtitle">The best Ruby on Rails skills and rules built by our community, for coding agents</p>
+
+          <input type="search" id="skills-search" class="skills-search" placeholder="Search skills..." autocomplete="off">
+
+          <p class="skills-updated">Last updated: {{ site.data.skills.last_updated | date: "%B %-d, %Y" }}</p>
+
+          <p class="skills-contribute">Missing one? <a href="https://github.com/rubyuy/ruby.uy/tree/main/_skills">Contribute a skill or rule</a> — anyone can add one.</p>
+        </section>
+
+        <section id="skills-list">
+          {% assign skills = site.data.skills.skills %}
+
+          {% if skills.size == 0 %}
+            <p class="skills-empty">No skills published yet — be the first to add one.</p>
+          {% endif %}
+
+          {% assign categories = skills | group_by: "category" %}
+          {% for category in categories %}
+            <h3 class="skills-category">{{ category.name | default: "Other" }}</h3>
+
+            {% for skill in category.items %}
+              {% capture search_text %}{{ skill.name }} {{ skill.description }} {{ skill.topics | join: ' ' }}{% endcapture %}
+
+              {% include skill_card.html %}
+            {% endfor %}
+          {% endfor %}
+        </section>
+      </article>
+    </main>
+
+    {% include footer.html %}
+  </body>
+</html>

--- a/_sass/skills.scss
+++ b/_sass/skills.scss
@@ -1,0 +1,340 @@
+#view-skills {
+  h2 {
+    overflow-wrap: break-word;
+
+    @media (max-width: 480px) {
+      font-size: 1.75rem;
+    }
+  }
+
+  .skills-subtitle {
+    color: #2E2E2E;
+    margin-bottom: 1.5rem;
+    opacity: 0.7;
+  }
+
+  .skills-search {
+    background-color: #F6EEEC;
+    border: 3px solid #2E2E2E;
+    box-shadow: 6px 6px 0 #3967D1;
+    color: #3967D1;
+    font: 700 1rem 'Syncopate', sans-serif;
+    letter-spacing: 0.05em;
+    padding: 1rem 1.25rem;
+    text-transform: uppercase;
+    transition: box-shadow 0.15s ease, transform 0.15s ease;
+    width: 100%;
+
+    &::placeholder {
+      color: #3967D1;
+      opacity: 0.5;
+    }
+
+    &:focus {
+      box-shadow: 6px 6px 0 #FFC24D;
+      outline: none;
+      transform: translate(-2px, -2px);
+    }
+  }
+
+  .skills-updated {
+    color: #2E2E2E;
+    font-size: 0.85rem;
+    margin-top: 0.75rem;
+    opacity: 0.6;
+  }
+
+  .skills-contribute {
+    color: #2E2E2E;
+    font-size: 0.85rem;
+    margin-top: 1.5rem;
+    opacity: 0.8;
+
+    a {
+      color: #3967D1;
+    }
+  }
+
+  .skills-empty {
+    color: #2E2E2E;
+    opacity: 0.7;
+  }
+
+  .skills-category {
+    border-bottom: 2px solid #3967D1;
+    color: #3967D1;
+    font-size: 1.5rem;
+    font-weight: bold;
+    margin: 2rem 0 1rem;
+    padding-bottom: 0.5rem;
+
+    &:first-child { margin-top: 0; }
+  }
+
+  .skill {
+    border: 3px solid #2E2E2E;
+    box-shadow: 4px 4px 0 #2E2E2E;
+    margin: 1rem 0;
+    padding: 1.25rem 1.5rem;
+    position: relative;
+    transition: box-shadow 0.15s ease, transform 0.15s ease;
+
+    &[hidden] { display: none; }
+
+    &:hover {
+      box-shadow: 6px 6px 0 #3967D1;
+      transform: translate(-2px, -2px);
+    }
+
+    h4 {
+      align-items: center;
+      display: flex;
+      flex-wrap: wrap;
+      font-size: 1.1rem;
+      gap: 0.5rem;
+
+      a {
+        color: #2E2E2E;
+        text-decoration: none;
+
+        &:hover { color: #3967D1; }
+
+        // Stretches the link over the whole card
+        &::after {
+          content: "";
+          inset: 0;
+          position: absolute;
+        }
+      }
+    }
+  }
+
+  .skill-type {
+    background-color: #F6EEEC;
+    border: 2px solid #2E2E2E;
+    font-size: 0.65rem;
+    letter-spacing: 0.05em;
+    padding: 0.15rem 0.4rem;
+    text-transform: uppercase;
+
+    &-rule {
+      background-color: #FFC24D;
+    }
+  }
+
+  .skill-description {
+    color: #2E2E2E;
+    margin: 0.5rem 0;
+    opacity: 0.8;
+  }
+
+  .skill-topics {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    margin-top: 0.75rem;
+  }
+
+  .skill-topic {
+    background-color: #F6EEEC;
+    border: 2px solid #2E2E2E;
+    color: #2E2E2E;
+    font-size: 0.7rem;
+    letter-spacing: 0.05em;
+    padding: 0.2rem 0.5rem;
+    text-transform: uppercase;
+  }
+}
+
+#view-skill {
+  section:first-child {
+    @media (min-width: 769px) {
+      max-width: 60%;
+    }
+  }
+
+  .skill-back {
+    color: #3967D1;
+    font-size: 0.85rem;
+    text-decoration: none;
+
+    &:hover { text-decoration: underline; }
+  }
+
+  h2 {
+    margin: 1.25rem 0 1rem;
+    overflow-wrap: break-word;
+  }
+
+  .skill-detail-description {
+    color: #2E2E2E;
+    line-height: 1.6;
+    margin-bottom: 2rem;
+    opacity: 0.7;
+  }
+
+  .skill-toolbar {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 1rem;
+  }
+
+  .skill-tabs {
+    display: flex;
+    gap: 0.5rem;
+  }
+
+  .skill-tab {
+    background: none;
+    border: 2px solid #2E2E2E;
+    color: #2E2E2E;
+    cursor: pointer;
+    font: 700 0.75rem 'Syncopate', sans-serif;
+    letter-spacing: 0.05em;
+    padding: 0.5rem 1rem;
+    text-transform: uppercase;
+
+    &.active {
+      background-color: #2E2E2E;
+      color: #F6EEEC;
+    }
+  }
+
+  .skill-copy-btn {
+    background-color: #FFC24D;
+    border: 2px solid #2E2E2E;
+    color: #2E2E2E;
+    cursor: pointer;
+    font: 700 0.75rem 'Syncopate', sans-serif;
+    letter-spacing: 0.05em;
+    padding: 0.5rem 1.25rem;
+    text-transform: uppercase;
+    transition: background-color 0.15s ease;
+
+    &:hover { background-color: #3967D1; color: #fff; }
+  }
+
+  .skill-markdown,
+  .skill-raw {
+    background-color: #fff;
+    border: 1px solid #ddd4d1;
+    font-family: 'DM Sans', sans-serif;
+  }
+
+  .skill-markdown {
+    color: #2E2E2E;
+    counter-reset: skill-rule;
+    font-size: 1rem;
+    line-height: 1.65;
+    padding: 2.5rem 3rem;
+
+    h1 {
+      font: 700 1.6rem 'Syncopate', sans-serif;
+      letter-spacing: -0.01em;
+      margin-bottom: 1.75rem;
+    }
+
+    h2 {
+      color: #3967D1;
+      font-size: 1.05rem;
+      font-weight: 700;
+      margin: 2rem 0 0.75rem;
+    }
+
+    p { margin: 0.85rem 0; }
+
+    ol {
+      list-style: none;
+      margin: 0 0 1.25rem;
+      padding-left: 0;
+
+      li {
+        border-top: 1px solid #eee2df;
+        counter-increment: skill-rule;
+        padding: 0.9rem 0 0.9rem 1.75rem;
+
+        &:first-child { border-top: none; }
+
+        &::before {
+          color: #3967D1;
+          content: counter(skill-rule) ".";
+          display: inline-block;
+          font-weight: 700;
+          margin-left: -1.75rem;
+          width: 1.75rem;
+        }
+
+        p {
+          display: inline;
+          margin: 0;
+        }
+      }
+    }
+
+    ul {
+      margin: 0.5rem 0 1.25rem;
+      padding-left: 0;
+
+      li {
+        margin: 0.4rem 0;
+        padding-left: 1.25rem;
+        position: relative;
+
+        &::before {
+          color: #3967D1;
+          content: "–";
+          left: 0;
+          position: absolute;
+        }
+      }
+    }
+
+    strong { font-weight: 700; }
+
+    code {
+      background-color: #F6EEEC;
+      font-family: 'Courier New', monospace;
+      font-size: 0.85em;
+      padding: 0.1rem 0.35rem;
+    }
+
+    pre {
+      background-color: #f6f8fa;
+      border: 1px solid #ddd4d1;
+      color: #2E2E2E;
+      margin: 1.1rem 0;
+      overflow-x: auto;
+      padding: 1.25rem 1.5rem;
+
+      code {
+        background: none;
+        color: inherit;
+        font-size: 0.85rem;
+        padding: 0;
+      }
+    }
+
+    // Rouge syntax highlighting tokens
+    .c, .c1 { color: #6a737d; font-style: italic; } // comments
+    .s2 { color: #b3372c; } // strings
+    .ss { color: #3967D1; } // symbols
+    .k, .kp { color: #7a3e9d; } // keywords
+    .no { color: #b3372c; } // constants
+    .p, .o { color: #6a737d; } // punctuation / operators
+    .nf { color: #397E78; } // method names
+    .mi, .mf { color: #b3372c; } // numbers
+  }
+
+  .skill-raw {
+    color: #F6EEEC;
+    background-color: #2E2E2E;
+    font-family: 'Courier New', monospace;
+    font-size: 0.85rem;
+    line-height: 1.6;
+    overflow-x: auto;
+    padding: 2rem;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+}

--- a/_skills/rspec-tests-for-rails.md
+++ b/_skills/rspec-tests-for-rails.md
@@ -1,0 +1,289 @@
+---
+name: rspec-tests-for-rails
+description: Reglas para escribir tests RSpec rápidos y mantenibles en proyectos Rails - build_stubbed sobre build/create, let sobre before, minimizar create_list, evitar N+1 en specs, memoizar el subject. Usar cuando el usuario pida escribir, revisar o refactorizar specs de RSpec en un proyecto Rails.
+---
+
+# Rules to create RSpec tests
+
+1. Prefer `let` instead of `before` blocks where possible.
+
+2. Prefer `build_stubbed` over `build` for memory-only objects — `build` is not as innocuous as it seems; if the object has associations, FactoryBot will call `create` on them, touching the DB anyway.
+
+- Use `build_stubbed`: creates an object with ID, timestamps and associations (also stubbed) without touching the DB. It's the fastest option.
+- Use `build`: only if you need to pass database validations or if you plan to call `.save` manually in the test.
+
+```ruby
+# Bad - build may still hit DB for associations
+let(:user) { build(:user) }
+
+# Good - completely in-memory, no DB touches
+let(:user) { build_stubbed(:user) }
+```
+
+3. Do not mock or stub a method call when you can set up the test to use real data instead.
+
+4. When you do need a double, use a verifying double — a plain `double` or a bare `allow(...).to receive(...)` never checks that the method exists, so the spec stays green after the real method is renamed or its signature changes. `instance_double` and `class_double` validate against the real class.
+
+```ruby
+# Bad - passes even if PaymentGateway#charge! no longer exists
+let(:gateway) { double(charge!: true) }
+
+# Good - fails if the method or its arity changes
+let(:gateway) { instance_double(PaymentGateway, charge!: true) }
+```
+
+Avoid `allow_any_instance_of` entirely: it stubs a method on every instance, hides which object is under test, and is not verified.
+
+5. Use `let` to reduce duplication in tests. If a value is only used by a single example, a plain local variable inside the `it` is clearer than a `let` far away from its usage.
+
+6. When writing a series of tests that share the same execution in the expect statement, set the `subject` at the beginning of the test block and use it across the tests.
+
+7. Use "shorthand hashes" / syntactic sugar for hashes to avoid redundancy.
+
+8. Test all the public methods in each class.
+
+9. Test private methods only indirectly, through the public methods of the same class.
+
+10. Use the minimum count in `create_list` — centralizing is good, but volume kills performance.
+
+```ruby
+# Bad - creates 10 records just to test that a scope returns results
+create_list(:user, 10)
+
+# Good - if the test passes with 2, you probably don't need 10
+create_list(:user, 2)
+```
+
+**Pro tip**: if you need to test pagination, stub the `per_page` value instead of creating 50 records.
+
+11. Use `build_stubbed` for "leaf" associations — when you create an object with `create`, but its associations don't need to be in the database for the logic under test, stub the association inside the `create`.
+
+```ruby
+# Bad - creates both in DB
+let(:profile) { create(:profile, user: create(:user)) }
+
+# Good - creates profile in DB, but user is just a stubbed memory object
+let(:profile) { create(:profile, user: build_stubbed(:user)) }
+```
+
+Useful when the main model requires a valid `user_id` for validations, but you won't run queries that JOIN against the users table.
+
+12. Preload nested associations to avoid N+1 in specs — sometimes the test is slow not because of creation, but because of execution. Reading a column off an already-loaded association is free; walking into a *nested* association inside a loop is what triggers one query per record.
+
+```ruby
+# Bad - one extra query per child to fetch its author
+let(:parent) { create(:parent) }
+before { create_list(:child, 10, parent: parent) }
+
+it "lists the authors" do
+  expect(parent.children.map { |child| child.author.name }).to all(be_present)
+end
+
+# Good - preload the nested association and use the preloaded relation
+it "lists the authors" do
+  children = parent.children.includes(:author)
+
+  expect(children.map { |child| child.author.name }).to all(be_present)
+end
+```
+
+Note that `parent.children.reload.includes(:author)` does **not** work: `reload` returns the already-loaded collection and the relation built by `includes` is discarded. You have to use the relation that `includes` returns.
+
+13. Use "transient attributes" in factories — instead of creating extra records in a `let` just so the main object has a specific state, use transient attributes in the factory to handle complex creation logic without cluttering the spec.
+
+```ruby
+# Factory definition
+factory :invoice do
+  transient do
+    item_count { 3 }
+  end
+
+  after(:create) do |invoice, evaluator|
+    create_list(:item, evaluator.item_count, invoice: invoice)
+  end
+end
+
+# Spec - clear and fast
+let(:invoice) { create(:invoice, item_count: 1) } # Default was 3, we optimized to 1
+```
+
+14. Memoize expensive subjects and use `described_class` — make sure the subject is not recalculated on every call. For services that mutate state, call the subject once in a `before` block, or use `let!` if the side effect is required for expectations.
+
+```ruby
+# Bad - subject recalculates on each call
+subject { described_class.new(params).call }
+
+it "creates a record" do
+  expect { subject }.to change(User, :count).by(1)
+end
+
+it "returns success" do
+  expect(subject).to be_success # This calls the service AGAIN!
+end
+
+# Good - call once, test the result
+subject(:result) { described_class.new(params).call }
+
+before { result } # Execute once
+
+it "creates a record" do
+  expect(User.count).to eq(1)
+end
+
+it "returns success" do
+  expect(result).to be_success
+end
+
+# Alternative with let! for side effects
+let!(:result) { described_class.new(params).call }
+
+it "creates a record" do
+  expect(User.count).to eq(1)
+end
+```
+
+15. Group related expectations with `aggregate_failures` instead of splitting them into many one-line examples — every example re-runs the whole `let` / `before` setup, so five examples over the same expensive subject pay that cost five times. `aggregate_failures` reports every failure in the block instead of stopping at the first one, so you keep the diagnostics without the extra setup.
+
+```ruby
+# Bad - the service runs once per example
+it { expect(result).to be_success }
+it { expect(result.user).to be_persisted }
+it { expect(result.errors).to be_empty }
+
+# Good - one setup, and a failure in the first line still reports the rest
+it "returns a successful result" do
+  aggregate_failures do
+    expect(result).to be_success
+    expect(result.user).to be_persisted
+    expect(result.errors).to be_empty
+  end
+end
+```
+
+16. Freeze the clock in anything time-sensitive — a spec that reads the real clock more than once can straddle a second, a day or a month boundary and fail intermittently, usually in CI and never on your machine.
+
+```ruby
+# Bad - the two reads of the clock can land in different seconds
+it "does not expire before 24 hours" do
+  token = create(:token, created_at: 24.hours.ago + 1.second)
+
+  expect(token).not_to be_expired # flaky: if a second elapses, it IS expired
+end
+
+# Good - one fixed instant for the whole example
+it "does not expire before 24 hours" do
+  freeze_time do
+    token = create(:token, created_at: 24.hours.ago + 1.second)
+
+    expect(token).not_to be_expired
+  end
+end
+```
+
+Use `travel_to(Date.new(2026, 2, 29))` when the logic depends on the calendar itself — end of month, leap years, DST switches.
+
+17. Never let a spec make a real HTTP call. Stub every outbound request with WebMock (or record it with VCR): a live call ties your suite to the network, to a third party's uptime and to data you don't control.
+
+```ruby
+# Bad - real network call: breaks with no internet, or when the API is slow or down
+it "fetches the exchange rate" do
+  expect(ExchangeRateService.call).to eq(40.5)
+end
+
+# Good - deterministic stubbed response
+it "fetches the exchange rate" do
+  stub_request(:get, "https://api.exchangerate.com/v1")
+    .to_return(status: 200, body: { rate: 40.5 }.to_json)
+
+  expect(ExchangeRateService.call).to eq(40.5)
+end
+
+# The real payoff: the failure paths you could never trigger against the live API
+it "falls back when the provider times out" do
+  stub_request(:get, "https://api.exchangerate.com/v1").to_timeout
+
+  expect(ExchangeRateService.call).to eq(ExchangeRateService::FALLBACK)
+end
+```
+
+18. Don't lean on `first` / `last` to mean "the oldest" or "the newest". With no explicit `order`, Rails falls back to primary-key order, which is only a proxy for insertion order — a backfill, an import or a data migration breaks that assumption silently.
+
+```ruby
+# Bad - `last` orders by id desc, so an imported invoice with a higher id
+# silently becomes "the latest one"
+expect(user.invoices.last).to eq(latest_invoice)
+
+# Good - order by the column that carries the business meaning
+expect(user.invoices.order(:issued_at).last).to eq(latest_invoice)
+```
+
+If the model already exposes a `scope :latest`, assert through the scope instead of rebuilding the ordering in the spec.
+
+19. Pin both ends of a `change` matcher. A bare `change` already fails when nothing changes, so that is not the risk — the risk is that it stays green when the value changes to the *wrong* thing.
+
+```ruby
+# Bad - a bug setting "failed" instead of "completed" still turns this green
+expect { process_payment }.to change(order, :status)
+
+# Good - pins the exact transition
+expect { process_payment }.to change(order, :status).from("pending").to("completed")
+```
+
+20. Split background work across two specs instead of running jobs inline. In the caller's spec assert only that the job was enqueued with the right arguments; test what the job actually does in the job's own spec, with `perform_now`.
+
+```ruby
+# Caller spec - assert it was enqueued, never run the job inline
+it "enqueues photo processing" do
+  expect { service.call }
+    .to have_enqueued_job(PhotoProcessingJob).with(photo.id)
+end
+
+# Job spec - here you DO test the work
+RSpec.describe PhotoProcessingJob do
+  it "marks the photo as processed" do
+    described_class.perform_now(photo.id)
+
+    expect(photo.reload).to be_processed
+  end
+end
+```
+
+21. Keep `if`, `unless`, `case` and loops out of your examples. Beyond the readability cost, a conditional lets an example pass having asserted nothing at all — the worst kind of green.
+
+```ruby
+# Bad - if no user is active, this example passes without running a single expectation
+it "notifies active users" do
+  users.each do |user|
+    expect(Notifier.call(user)).to be_success if user.active?
+  end
+end
+
+# Good - one context per scenario, with explicit setup in each
+context "when the user is active" do
+  let(:user) { build_stubbed(:user, :active) }
+
+  it "notifies the user" do
+    expect(Notifier.call(user)).to be_success
+  end
+end
+
+context "when the user is inactive" do
+  let(:user) { build_stubbed(:user, :inactive) }
+
+  it "does not notify the user" do
+    expect(Notifier.call(user)).to be_a_failure
+  end
+end
+```
+
+22. Each test seeds `srand` with the current (configurable) RSpec seed. This means `Array#shuffle`, `Array#sample` and `rand` are all repeatable if you provide the original seed, with the caveat that it must run during a test run (e.g. inside a `let`, `let!` or `it`).
+
+```bash
+$ rspec
+...
+Randomized with seed 17999
+...
+$ rspec --seed 17999     # rerun with the same seed
+```
+
+23. Add an explicit `require "rails_helper"` to the test file if it needs Rails.

--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -1,3 +1,3 @@
 ---
 ---
-@import 'reset', 'application', 'header', 'nav', 'next_meetup', 'view', 'meetups', 'sponsors', 'footer', 'talks', 'community', 'project-card', 'stats', 'primera-vez';
+@import 'reset', 'application', 'header', 'nav', 'next_meetup', 'view', 'meetups', 'sponsors', 'footer', 'talks', 'community', 'project-card', 'stats', 'primera-vez', 'skills';

--- a/assets/js/skill.js
+++ b/assets/js/skill.js
@@ -1,0 +1,27 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const copyButton = document.querySelector("#skill-copy");
+  const source = document.querySelector("#skill-source");
+  const markdown = document.querySelector("#skill-markdown");
+  const tabs = document.querySelectorAll(".skill-tab");
+
+  if (copyButton && source) {
+    copyButton.addEventListener("click", async () => {
+      await navigator.clipboard.writeText(source.textContent);
+      copyButton.textContent = "Copied!";
+      setTimeout(() => { copyButton.textContent = "Copy"; }, 1500);
+    });
+  }
+
+  if (tabs.length && markdown && source) {
+    tabs.forEach((tab) => {
+      tab.addEventListener("click", () => {
+        document.querySelector(".skill-tab.active")?.classList.remove("active");
+        tab.classList.add("active");
+
+        const showRaw = tab.dataset.view === "raw";
+        markdown.hidden = showRaw;
+        source.hidden = !showRaw;
+      });
+    });
+  }
+});

--- a/assets/js/skills.js
+++ b/assets/js/skills.js
@@ -1,0 +1,16 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const list = document.querySelector("#skills-list");
+  const input = document.querySelector("#skills-search");
+
+  if (!input || !list) return;
+
+  const skillNodes = [...list.querySelectorAll(".skill")];
+
+  input.addEventListener("input", (e) => {
+    const query = e.target.value.trim().toLowerCase();
+
+    skillNodes.forEach((skill) => {
+      skill.hidden = query && !skill.dataset.search?.toLowerCase().includes(query);
+    });
+  });
+});

--- a/skills.html
+++ b/skills.html
@@ -1,0 +1,5 @@
+---
+layout: skills
+permalink: /skills/
+page_scripts: [skills]
+---


### PR DESCRIPTION
## Context

Most of us already have a CLAUDE.md, a .cursorrules or something similar sitting in a project, with our rules for specs, for security, for performance. They are roughly the same rules, written many times over, each copy slightly different and none of them reviewed by anyone else.

This proposes keeping the good ones in one place instead.

## What it adds

A `/skills/` section linked from the home page: one page per skill, grouped by category, with a raw view and a copy button. No author attribution, skills belong to the community. Seeded with `rspec-tests-for-rails`.

## The call

Draft on purpose, the interesting part is which skills we want and what goes in them, not the code. To add one: drop the document in `_skills/<name>.md` and add its entry to `_data/skills.yml`. Categories are open too.

## Screenshots
<img width="1920" height="1080" alt="Screenshot 2026-08-17 at 9 16 42 AM" src="https://github.com/user-attachments/assets/d2eb66f7-7820-4887-a75a-8cf446f145cb" />
<img width="1920" height="1080" alt="Screenshot 2026-08-17 at 9 16 46 AM" src="https://github.com/user-attachments/assets/0867b25c-2ec3-46ca-b602-3303f4bb8907" />


## QA steps

1. Go to `/skills/`, check the search filters the cards
2. Open the skill, switch between Markdown and Raw, hit Copy